### PR TITLE
ut fixes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as _in:
 
 setuptools.setup(
     name="prophecy-build-tool",
-    version="1.2.5-dev1",
+    version="1.2.5-dev2",
     author="Prophecy",
     author_email="maciej@prophecy.io",
     description="Prophecy-build-tool (PBT) provides utilities to build and distribute projects created from the "
@@ -39,6 +39,7 @@ setuptools.setup(
     ],
     extras_require={
         "test": [
+            "pytest-html",
             "pytest",
             "pyspark==3.3.0",
             "mock",  # or any other testing-specific packages you need

--- a/src/pbt/v2/deployment/jobs/airflow.py
+++ b/src/pbt/v2/deployment/jobs/airflow.py
@@ -443,7 +443,7 @@ class AirflowJobDeployment:
                 log(f"Failed to pause dag with name {dag_name} for job {job_id} and fabric {job_data.fabric_id}",
                     exception=e, step_id=self._ADD_JOBS_STEP_ID)
 
-            log(f"Successfully added job {dag_name} for job_id {job_id}", step_id=self._ADD_JOBS_STEP_ID)
+            log(f"Successfully added job {dag_name} for job_id {job_id} on fabric {job_data.fabric_id}", step_id=self._ADD_JOBS_STEP_ID)
 
             job_info = JobInfo.create_airflow_job(job_data.name, job_id, job_data.fabric_id, dag_name,
                                                   self._project.release_tag,

--- a/src/pbt/v2/deployment/pipeline.py
+++ b/src/pbt/v2/deployment/pipeline.py
@@ -90,11 +90,11 @@ class PipelineDeployment:
 
     def deploy(self):
 
-        if not self.has_pipelines:
-            responses = self.build_and_upload()
+        failed_response = []
 
-            if any(response.is_left for response in responses):
-                return responses
+        if not self.has_pipelines:
+            build_response = self.build_and_upload()
+            failed_response = [response for response in build_response if response.is_left]
 
         futures = []
         with ThreadPoolExecutor(max_workers=3) as executor:
@@ -114,7 +114,8 @@ class PipelineDeployment:
         for future in as_completed(futures):
             responses.append(future.result())
 
-        return responses
+        # merging the failed responses from build and upload.
+        return responses + failed_response
 
     @property
     def _pipeline_to_list_fabrics(self) -> Dict[str, List[str]]:

--- a/src/pbt/v2/deployment/pipeline.py
+++ b/src/pbt/v2/deployment/pipeline.py
@@ -99,13 +99,16 @@ class PipelineDeployment:
         futures = []
         with ThreadPoolExecutor(max_workers=3) as executor:
             for pipeline_id, list_of_entities_to_fabric_id in self._pipeline_to_list_fabrics.items():
-                pipeline_uploader = PipelineUploadManager(self.project, self.project_config, pipeline_id,
-                                                          list_of_entities_to_fabric_id,
-                                                          self.pipeline_id_to_local_path[pipeline_id])
+                # ignore pipelines that are not in the list of pipelines to build.
+                # they are already failed.
+                if pipeline_id in self.pipeline_id_to_local_path:
+                    pipeline_uploader = PipelineUploadManager(self.project, self.project_config, pipeline_id,
+                                                              list_of_entities_to_fabric_id,
+                                                              self.pipeline_id_to_local_path[pipeline_id])
 
-                futures.append(
-                    executor.submit(
-                        lambda uploader=pipeline_uploader: uploader.upload_pipeline()))
+                    futures.append(
+                        executor.submit(
+                            lambda uploader=pipeline_uploader: uploader.upload_pipeline()))
 
         responses = []
         for future in as_completed(futures):
@@ -195,6 +198,7 @@ class PackageBuilder:
                     self.wheel_build()
 
                 path = Project.get_pipeline_whl_or_jar(self._base_path)
+                log(f"Pipeline package built successfully, with path {path}", step_id=self._pipeline_id)
 
                 if self._project_config.system_config.nexus is not None:
                     log("Trying to upload pipeline package to nexus.", self._pipeline_id)
@@ -244,7 +248,8 @@ class PackageBuilder:
 
     def mvn_build(self):
         mvn = "mvn"
-        command = [mvn, "package", "-DskipTests"] if not self._are_tests_enabled else [mvn, "package"]
+        command = [mvn, "package", "-DskipTests"] if not self._are_tests_enabled else [mvn, "package",
+                                                                                       "-Dfabric=default"]
 
         log(f"Running mvn command {command}", step_id=self._pipeline_id)
 
@@ -253,13 +258,11 @@ class PackageBuilder:
     def wheel_build(self):
         response_code = 0
         if self._are_tests_enabled:
-            test_command = ["python3", "-m", "pytest", "-v", f"{self._base_path}/test/TestSuite.py",
-                            f"--html={self._base_path}/report.html",
-                            "--self-contained-html", f"--junitxml={self._base_path}/report.xml"""]
+            test_command = ["python3", "-m", "pytest", "-v", f"{self._base_path}/test/TestSuite.py"]
             log(f"Running python test {test_command}", step_id=self._pipeline_id)
             response_code = self._build(test_command)
 
-            if response_code != 0:
+            if response_code not in (0, 5):
                 raise Exception(f"Python test failed for pipeline {self._pipeline_id}")
 
         command = ["python3", "setup.py", "bdist_wheel"]
@@ -308,8 +311,8 @@ class PackageBuilder:
         # Get the exit code
         return_code = process.wait()
 
-        if return_code == 0:
-            log("Build was successful.", step_id=self._pipeline_id)
+        if return_code in (0, 5):
+            log(f"Build was successful with exit code {return_code}", step_id=self._pipeline_id)
         else:
             log(f"Build failed with exit code {return_code}", step_id=self._pipeline_id)
             raise ProjectBuildFailedException(f"Build failed with exit code {return_code}")

--- a/src/pbt/v2/deployment/project.py
+++ b/src/pbt/v2/deployment/project.py
@@ -145,16 +145,10 @@ class ProjectDeployment:
     def _deploy_databricks_jobs(self) -> List[Either]:
         databricks_jobs_responses = self._databricks_jobs.deploy()
 
-        if databricks_jobs_responses is not None and any(response.is_left for response in databricks_jobs_responses):
-            raise Exception("Databricks jobs deployment failed.")
-
         return databricks_jobs_responses
 
     def _deploy_airflow_jobs(self) -> List[Either]:
         airflow_jobs_responses = self._airflow_jobs.deploy()
-
-        if airflow_jobs_responses is not None and any(response.is_left for response in airflow_jobs_responses):
-            raise Exception("Airflow jobs deployment failed.")
 
         return airflow_jobs_responses
 


### PR DESCRIPTION
1. pytest-html in test for setup.py
2. clubbing failed pipeline build response for status with upload statues.
3. passing default fabric for mvn tests.
4. ignoring response_code `5` for tests run when no tests are running in python.
5. removing databricks / airflow failures in their methods and bubbling up after writing states to file. 