### PR TITLE
fixing bug in v2 where driver path was never honored and adding enhancement for path

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as _in:
 
 setuptools.setup(
     name="prophecy-build-tool",
-    version="1.2.21",
+    version="1.2.22",
     author="Prophecy",
     author_email="maciej@prophecy.io",
     description="Prophecy-build-tool (PBT) provides utilities to build and distribute projects created from the "

--- a/src/pbt/prophecy_build_tool.py
+++ b/src/pbt/prophecy_build_tool.py
@@ -869,8 +869,27 @@ class ProphecyBuildTool:
         # import random
         # uniqueKey = random.random()
         # jars_unique_key: str = f"driver_library_path_{uniqueKey}"
-        os.environ["SPARK_JARS_CONFIG"] = build_jars if build_jars else ""
-        # return jars_unique_key
+        if build_jars:
+            if os.path.isdir(build_jars):
+                driver_library_path = os.path.abspath(build_jars)
+                jar_files = ",".join(
+                    [os.path.join(driver_library_path, file) for file in os.listdir(driver_library_path) if
+                     file.endswith('.jar')])
+                os.environ["SPARK_JARS_CONFIG"] = jar_files
+            elif os.path.isfile(build_jars):
+                driver_library_path = os.path.abspath(build_jars)
+                os.environ["SPARK_JARS_CONFIG"] = driver_library_path
+            elif "," in build_jars:  # allow comma separated list of files
+                for item in build_jars.split(","):
+                    assert(os.path.isfile(item))
+                jar_files = ",".join([os.path.abspath(f) for f in build_jars.split(',')])
+                os.environ["SPARK_JARS_CONFIG"] = jar_files
+
+        if "SPARK_JARS_CONFIG" in os.environ:
+            print(f"    Using env SPARK_JARS_CONFIG={os.environ['SPARK_JARS_CONFIG']}")
+        else:
+            os.environ["SPARK_JARS_CONFIG"] = ""
+            print("    Using default spark jars locations")
 
     def removeJarsKeyFromEnv(self):
         del os.environ["SPARK_JARS_CONFIG"]

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -5,6 +5,57 @@ import os
 PROJECT_PATH = str(os.getcwd()) + "/test/resources/HelloWorld"
 
 
+def test_test_v2_driver_paths1():
+    runner = CliRunner()
+    with open('./fake.jar', 'w') as fd:
+        fd.write("fake")
+    with open('./fake2.jar', 'w') as fd:
+        fd.write("fake")
+
+    result = runner.invoke(test_v2, ["--path", PROJECT_PATH, "--driver-library-path", "./"])
+    print(result.output)
+    assert "fake.jar" in result.output
+    assert "fake2.jar" in result.output
+
+
+def test_test_v2_driver_paths2():
+    runner = CliRunner()
+    with open('./fake.jar', 'w') as fd:
+        fd.write("fake")
+    with open('./fake2.jar', 'w') as fd:
+        fd.write("fake")
+
+    result = runner.invoke(test_v2, ["--path", PROJECT_PATH, "--driver-library-path", "./fake.jar,fake2.jar"])
+    print(result.output)
+    assert "fake.jar" in result.output
+    assert "fake2.jar" in result.output
+
+
+def test_test_v2_driver_paths3():
+    runner = CliRunner()
+    with open('./fake.jar', 'w') as fd:
+        fd.write("fake")
+    with open('./fake2.jar', 'w') as fd:
+        fd.write("fake")
+
+    result = runner.invoke(test_v2, ["--path", PROJECT_PATH, "--driver-library-path", os.getcwd()])
+    print(result.output)
+    assert "fake.jar" in result.output
+    assert "fake2.jar" in result.output
+
+def test_driver_paths():
+    runner = CliRunner()
+    with open('./fake.jar', 'w') as fd:
+        fd.write("fake")
+    with open('./fake2.jar', 'w') as fd:
+        fd.write("fake")
+
+    result = runner.invoke(test, ["--path", PROJECT_PATH, "--driver-library-path", "./"])
+    print(result.output)
+    assert "fake.jar" in result.output
+    assert "fake2.jar" in result.output
+
+
 def test_test_path_default():
     runner = CliRunner()
     result = runner.invoke(test, ["--path", PROJECT_PATH])
@@ -19,6 +70,7 @@ def test_test_path_default():
     assert "Unit Testing pipeline pipelines/report_top_customers" in result.output
     assert "Unit Testing pipeline pipelines/join_agg_sort" in result.output
     assert "Unit Testing pipeline pipelines/farmers-markets-irs" in result.output
+    assert "Using default spark jars locations" in result.output
 
 
 def test_test_v2_path_default():


### PR DESCRIPTION
in test-v2 we were never setting the --driver-library-path option because of a Capitalization issue (python vs PYTHON) when reading the project language from pbt_project.yml file. 

also that CLI arg was not very convenient so I added some additional parsing to allow you to specify relative file paths or directories and have it resolve all JAR files in that dir and to grab the full file paths automatically. 