### PR TITLE
coverage reports being generated were incorrect

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as _in:
 
 setuptools.setup(
     name="prophecy-build-tool",
-    version="1.2.23",
+    version="1.2.24",
     author="Prophecy",
     author_email="maciej@prophecy.io",
     description="Prophecy-build-tool (PBT) provides utilities to build and distribute projects created from the "

--- a/src/pbt/deployment/pipeline.py
+++ b/src/pbt/deployment/pipeline.py
@@ -470,8 +470,19 @@ class PackageBuilderAndUploader:
         return self._build(command)
 
     def wheel_test(self):
+        COVERAGERC_CONTENT = (
+            "[run]\n"
+            "omit=test/**,build/**,dist/**,setup.py\n"
+            "relative_files=True\n"
+        )
+
+        coveragerc_path = os.path.join(f"{self._base_path}", ".coveragerc")
+        if not os.path.exists(coveragerc_path):
+            with open(coveragerc_path, "w") as fd:
+                fd.write(COVERAGERC_CONTENT)
+
         separator = os.sep
-        test_command = ["python3", "-m", "pytest", "-v", "--cov=test", "--cov-report=xml", "--junitxml=report.xml",
+        test_command = ["python3", "-m", "pytest", "-v", "--cov=.", "--cov-report=xml", "--junitxml=report.xml",
                         f"{self._base_path}{separator}test{separator}TestSuite.py"]
         log(f"Running python test {test_command}", step_id=self._pipeline_id, indent=2)
         response_code = self._build(test_command)

--- a/src/pbt/prophecy_build_tool.py
+++ b/src/pbt/prophecy_build_tool.py
@@ -700,6 +700,16 @@ class ProphecyBuildTool:
         )
 
     def test_python(self, path_pipeline_absolute, path_pipeline):
+        COVERAGERC_CONTENT = (
+                "[run]\n"
+                "omit=test/**,build/**,dist/**,setup.py\n"
+                "relative_files=True\n"
+            )
+        coveragerc_path = os.path.join(path_pipeline_absolute, ".coveragerc")
+        if not os.path.exists(coveragerc_path):
+            with open(coveragerc_path, "w") as fd:
+                fd.write(COVERAGERC_CONTENT)
+
         return Process.process_sequential(
             [
                 # Install dependencies of particular pipeline
@@ -723,7 +733,7 @@ class ProphecyBuildTool:
                         "-m",
                         "pytest",
                         "-v",
-                        "--cov=test",  # generate coverage for module test
+                        "--cov=.",  # generate coverage for module test
                         "--cov-report=xml",  # XML format
                         "--junitxml=report.xml",
                         f"test{os.sep}TestSuite.py",

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -142,10 +142,53 @@ def test_test_with_pipeline_filter_all_notfound_pipelines():
 
 
 def test_test_coverage_and_test_report_generation():
+    coverage_path = os.path.join(PROJECT_PATH, "./pipelines/customers_orders/code/coverage.xml")
+    if os.path.exists(coverage_path):
+        os.remove(coverage_path)
+    coveragerc_path = os.path.join(PROJECT_PATH, "./pipelines/customers_orders/code/.coveragerc")
+    if os.path.exists(coveragerc_path):
+        os.remove(coveragerc_path)
     runner = CliRunner()
-    result = runner.invoke(test, ["--path", PROJECT_PATH, "--pipelines", "report_top_customers"])
+    result = runner.invoke(test, ["--path", PROJECT_PATH, "--pipelines", "customers_orders"])
     print(result.output)
-    assert "Unit Testing pipeline pipelines/report_top_customers" in result.output
+    assert "Unit Testing pipeline pipelines/customers_orders" in result.output
+    assert (os.path.exists(coverage_path))
+    assert (os.path.exists(os.path.join(PROJECT_PATH, "./pipelines/customers_orders/code/report.xml")))
+
+    with open(coverage_path, 'r') as fd:
+        content = fd.read()
+        # check to make sure that .coveragerc got picked up and made relative paths:
+        assert ("<source>.</source>" in content)
+        # verify that some coverage was written
+        assert ("<package name=\"job\"" in content)
+        # check that setup.py is ignored
+        assert ("<class name=\"setup.py\"" not in content)
+        # make sure we are not doing coverage for test directory
+        assert ("<package name=\"test\"" not in content)
+
+
+def test_test_v2_coverage_and_test_report_generation():
+    coverage_path = os.path.join(PROJECT_PATH, "./pipelines/customers_orders/code/coverage.xml")
+    if os.path.exists(coverage_path):
+        os.remove(coverage_path)
+    coveragerc_path = os.path.join(PROJECT_PATH, "./pipelines/customers_orders/code/.coveragerc")
+    if os.path.exists(coveragerc_path):
+        os.remove(coveragerc_path)
+    runner = CliRunner()
+    result = runner.invoke(test_v2, ["--path", PROJECT_PATH])
+    print(result.output)
+    assert "Testing pipeline `pipelines/customers_orders`" in result.output
     assert "Coverage XML written to file coverage.xml" in result.output
-    assert (os.path.exists(os.path.join(PROJECT_PATH, "./pipelines/report_top_customers/code/coverage.xml")))
-    assert (os.path.exists(os.path.join(PROJECT_PATH, "./pipelines/report_top_customers/code/report.xml")))
+    assert (os.path.exists(coverage_path))
+    assert (os.path.exists(os.path.join(PROJECT_PATH, "./pipelines/customers_orders/code/report.xml")))
+
+    with open(coverage_path, 'r') as fd:
+        content = fd.read()
+        # check to make sure that .coveragerc got picked up and made relative paths:
+        assert ("<source>.</source>" in content)
+        # verify that some coverage was written
+        assert ("<package name=\"job\"" in content)
+        # check that setup.py is ignored
+        assert ("<class name=\"setup.py\"" not in content)
+        # make sure we are not doing coverage for test directory
+        assert ("<package name=\"test\"" not in content)


### PR DESCRIPTION
. fixed paths and options to generate reports for correct source and relative paths. 

relative paths are necessary for sonarqube (common tool for ingesting these reports)

also excluded bad dirs like build/ test/ dist/ 