### PR TITLE
Rj/make coverage absolute

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as _in:
 
 setuptools.setup(
     name="prophecy-build-tool",
-    version="1.2.25",
+    version="1.2.26",
     author="Prophecy",
     author_email="maciej@prophecy.io",
     description="Prophecy-build-tool (PBT) provides utilities to build and distribute projects created from the "

--- a/src/pbt/deployment/pipeline.py
+++ b/src/pbt/deployment/pipeline.py
@@ -473,7 +473,6 @@ class PackageBuilderAndUploader:
         COVERAGERC_CONTENT = (
             "[run]\n"
             "omit=test/**,build/**,dist/**,setup.py\n"
-            "relative_files=True\n"
         )
 
         coveragerc_path = os.path.join(f"{self._base_path}", ".coveragerc")

--- a/src/pbt/prophecy_build_tool.py
+++ b/src/pbt/prophecy_build_tool.py
@@ -703,7 +703,6 @@ class ProphecyBuildTool:
         COVERAGERC_CONTENT = (
                 "[run]\n"
                 "omit=test/**,build/**,dist/**,setup.py\n"
-                "relative_files=True\n"
             )
         coveragerc_path = os.path.join(path_pipeline_absolute, ".coveragerc")
         if not os.path.exists(coveragerc_path):

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -157,8 +157,8 @@ def test_test_coverage_and_test_report_generation():
 
     with open(coverage_path, 'r') as fd:
         content = fd.read()
-        # check to make sure that .coveragerc got picked up and made relative paths:
-        assert ("<source>.</source>" in content)
+        # check to make sure that .coveragerc got picked up and made absolute paths:
+        assert ("<source>/" in content)
         # verify that some coverage was written
         assert ("<package name=\"job\"" in content)
         # check that setup.py is ignored
@@ -184,8 +184,8 @@ def test_test_v2_coverage_and_test_report_generation():
 
     with open(coverage_path, 'r') as fd:
         content = fd.read()
-        # check to make sure that .coveragerc got picked up and made relative paths:
-        assert ("<source>.</source>" in content)
+        # check to make sure that .coveragerc got picked up and made absolute paths:
+        assert ("<source>/" in content)
         # verify that some coverage was written
         assert ("<package name=\"job\"" in content)
         # check that setup.py is ignored


### PR DESCRIPTION
coverage tools like sonarqube often need file paths from the top level folder or absolute