### PR TITLE
added functionality to add pom.xml and list of coordinates to pyspark WHLs for dependency tracking

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as _in:
 
 setuptools.setup(
     name="prophecy-build-tool",
-    version="1.2.26",
+    version="1.2.27",
     author="Prophecy",
     author_email="maciej@prophecy.io",
     description="Prophecy-build-tool (PBT) provides utilities to build and distribute projects created from the "

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as _in:
 
 setuptools.setup(
     name="prophecy-build-tool",
-    version="1.2.25",
+    version="1.2.26",
     author="Prophecy",
     author_email="maciej@prophecy.io",
     description="Prophecy-build-tool (PBT) provides utilities to build and distribute projects created from the "

--- a/src/pbt/__init__.py
+++ b/src/pbt/__init__.py
@@ -76,9 +76,11 @@ def build(path, pipelines, ignore_build_errors, ignore_parse_errors):
     is_flag=True,
     required=False,
 )
-def build_v2(path, pipelines, ignore_build_errors, ignore_parse_errors):
+@click.option("--add-pom-python", default=False, is_flag=True,
+              help="adds pom.xml and MAVEN_COORDINATES files to pyspark pipeline WHL files", required=False)
+def build_v2(path, pipelines, ignore_build_errors, ignore_parse_errors, add_pom_python):
     pbt = PBTCli.from_conf_folder(path)
-    pbt.build(pipelines, ignore_build_errors, ignore_parse_errors)
+    pbt.build(pipelines, ignore_build_errors, ignore_parse_errors, add_pom_python)
 
 
 @cli.command()

--- a/src/pbt/deployment/pipeline.py
+++ b/src/pbt/deployment/pipeline.py
@@ -299,7 +299,6 @@ class PipelineDeployment:
                 with open(setup_py_path, 'w') as fd:
                     fd.write(setup_py_content_modified)
 
-
     def build(self, pipeline_names: str = "", ignore_build_errors: bool = False, ignore_parse_errors: bool = False):
         # these can be names and ids.
         all_pipeline_ids = self._pipeline_to_list_fabrics_full_deployment.keys()

--- a/src/pbt/deployment/pipeline.py
+++ b/src/pbt/deployment/pipeline.py
@@ -304,7 +304,8 @@ class PipelineDeployment:
                 with open(setup_py_path, 'w') as fd:
                     fd.write(setup_py_content_modified)
 
-    def build(self, pipeline_names: str = "", ignore_build_errors: bool = False, ignore_parse_errors: bool = False):
+    def build(self, pipeline_names: str = "", ignore_build_errors: bool = False, ignore_parse_errors: bool = False,
+              add_pom_python: bool = False):
         # these can be names and ids.
         all_pipeline_ids = self._pipeline_to_list_fabrics_full_deployment.keys()
         pipeline_ids_to_name = {
@@ -332,9 +333,7 @@ class PipelineDeployment:
                     f"{Colors.WARNING}Skipping build for pipelines {pipelines_to_skip_build}, Please check the ids/names of provided pipelines {Colors.ENDC}"
                 )
 
-        if self.project.pbt_project_dict.get('language', '') == 'python':
-            # TODO do we want to add this behind an option? seems like anyone who is using PBT
-            #  would want to include the maven dependency info as it is very handy.
+        if add_pom_python and self.project.pbt_project_dict.get('language', '') == 'python':
             self._add_maven_dependency_info_python()
 
         log(f"\n\n{Colors.OKBLUE}Building pipelines {len(pipeline_ids_to_name)}{Colors.ENDC}\n")

--- a/src/pbt/deployment/pipeline.py
+++ b/src/pbt/deployment/pipeline.py
@@ -249,7 +249,12 @@ class PipelineDeployment:
             # the plibs maven does not have a normal coordinate so we have to make one:
             spark_version = os.environ['SPARK_VERSION'] if 'SPARK_VERSION' in os.environ else '{{REPLACE_ME}}'
             plibs_maven_dep = [d for d in project_level_dependencies if d['type'] == 'plibMaven']
-            print(plibs_maven_dep)
+            if len(plibs_maven_dep) != 1:
+                log(
+                    f"{Colors.WARNING}Skipping creating POM for maven dependencies, pbt_project.yml is missing "
+                    f"prophecy-libs information. please update your prophecy-libs in the Prophecy UI{Colors.ENDC}"
+                )
+                return
             plibs_maven_dep = plibs_maven_dep[0]
             plibs_maven_dep['type'] = 'coordinates'
             plibs_maven_dep['package'] = 'prophecy-libs_2.12'

--- a/src/pbt/deployment/project.py
+++ b/src/pbt/deployment/project.py
@@ -102,8 +102,8 @@ class ProjectDeployment:
 
         return headers
 
-    def build(self, pipelines, ignore_build_errors, ignore_parse_errors):
-        self._pipelines.build(pipelines, ignore_build_errors, ignore_parse_errors)
+    def build(self, pipelines, ignore_build_errors, ignore_parse_errors, add_pom_python):
+        self._pipelines.build(pipelines, ignore_build_errors, ignore_parse_errors, add_pom_python)
 
     def validate(self, treat_warning_as_errors):
         self._pipelines.validate(treat_warning_as_errors)

--- a/src/pbt/pbt_cli.py
+++ b/src/pbt/pbt_cli.py
@@ -39,8 +39,8 @@ class PBTCli(object):
         project_config = ProjectConfig.from_conf_folder(project, conf_folder, fabric_ids, job_ids, skip_builds, migrate)
         return cls(project, project_config)
 
-    def build(self, pipelines, ignore_build_errors, ignore_parse_errors):
-        self.project.build(pipelines, ignore_build_errors, ignore_parse_errors)
+    def build(self, pipelines, ignore_build_errors, ignore_parse_errors, add_pom_python):
+        self.project.build(pipelines, ignore_build_errors, ignore_parse_errors, add_pom_python)
 
     def test(self, driver_library_path: str):
         if driver_library_path and str.upper(self.project.project.project_language) == "PYTHON":


### PR DESCRIPTION
If users are deploying WHL artifacts on a non-standard platform (not databricks or airflow) then it becomes very difficult to track any associated maven dependencies in pyspark. 

This PR aims to gather that dependency information into a more useful format (pom.xml and a list of coordinates) 

in simple situations the list of coordinates can be passed directly to the `--packages` option in a spark-submit command. Otherwise the POM.xml will have additional information including any repositories or exclusions for them to download the jars (`mvn dependency:copy-dependencies -DoutputDirectory=./`) and pass to `--jars`. 

The only thing that the user would need to do is **either** set SPARK_VERSION as an environment variable to choose which spark version of PLIBS to be installed (3.3.0, 3.4.0, 3.5.0, etc) **OR** else grep for {{SPARK_VERSION}} in the output files and replace it with a version string. 
