### PR TITLE
Rj/add versioning (bump-set-spike) AND tagging capabilities

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,8 +15,12 @@ pydantic~=1.10
 pydantic-yaml==1.1.1
 google-cloud-secret-manager==2.16.2 # similiar to what we have in execution service.
 boto3~=1.34.120
-requests~=2.31.0
+requests~=2.32.3
 tenacity==8.2.3
 pytest-html
 pytest-cov
 gitpython
+botocore~=1.34.154
+packaging~=24.1
+pyspark~=3.3.0
+parameterized~=0.9.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ requests~=2.31.0
 tenacity==8.2.3
 pytest-html
 pytest-cov
+gitpython

--- a/run_flake.sh
+++ b/run_flake.sh
@@ -1,3 +1,4 @@
 #!/bin/sh
 
-flake8 --exclude=.venv/ . --count --select=E9,F63,F7,F82 --show-source --statistics
+flake8 . --count --exclude=./test/resources/,./.venv/ --select=E9,F63,F7,F82 --show-source --statistics
+flake8 . --count --exclude=./test/resources/,./.venv/ --statistics

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setuptools.setup(
         "pydantic-yaml==1.1.1",
         "boto3~=1.34.120",
         "tenacity==8.2.3",
-        "gitpython"
+        "gitpython",
     ],
     extras_require={
         "test": [
@@ -46,6 +46,7 @@ setuptools.setup(
             "pyspark>=3.3.0,<4.0.0",
             "mock",  # or any other testing-specific packages you need
             "parameterized",
+            "gitpython",
         ]
     },
     python_requires=">=3.7",

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as _in:
 
 setuptools.setup(
     name="prophecy-build-tool",
-    version="1.2.26",
+    version="1.2.28",
     author="Prophecy",
     author_email="maciej@prophecy.io",
     description="Prophecy-build-tool (PBT) provides utilities to build and distribute projects created from the "

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setuptools.setup(
         "pydantic-yaml==1.1.1",
         "boto3~=1.34.120",
         "tenacity==8.2.3",
+        "gitpython"
     ],
     extras_require={
         "test": [

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ setuptools.setup(
             "pytest",
             "pyspark>=3.3.0,<4.0.0",
             "mock",  # or any other testing-specific packages you need
+            "parameterized",
         ]
     },
     python_requires=">=3.7",

--- a/src/pbt/__init__.py
+++ b/src/pbt/__init__.py
@@ -312,6 +312,54 @@ def versioning(path, _set, bump, force):
         raise click.UsageError("must give either '--set' or '--bump'")
 
 
+@cli.command()
+@click.option(
+    "--path",
+    help="Path to the directory containing the pbt_project.yml file",
+    required=True,
+)
+@click.option(
+    "--repo-path",
+    help="Path to the repository root. If left blank it will use '--path'",
+    required=False,
+)
+@click.option(
+    "--no-push",
+    default=False,
+    is_flag=True,
+    help="By default the tag will be pushed to the origin after it is created. Use this flag to skip pushing the tag.",
+    required=False,
+)
+@click.option(
+    "--no-branch",
+    default=False,
+    is_flag=True,
+    help="normally the tag is prefixed with the branch name: <project_name>/<branch_name>/<version>. "
+         "This removes the <branch_name>.",
+    required=False,
+)
+@click.option(
+    "--no-project",
+    default=False,
+    is_flag=True,
+    help="normally the tag is prefixed with the branch name: <project_name>/<branch_name>/<version>. "
+         "This removes the <project_name>.",
+    required=False,
+)
+@click.option(
+    "--custom",
+    default=False,
+    type=str,
+    help="Explicitly set the exact tag using a string. Ignores other options.",
+    required=False,
+)
+def tag(path, repo_path, no_push, no_branch, no_project, custom):
+    pbt = PBTCli.from_conf_folder(path)
+    if not repo_path:
+        repo_path = path
+    pbt.project.tag(repo_path, no_push=no_push, no_branch=no_branch, no_project=no_project, custom=custom)
+
+
 if __name__ == "pbt":
     print(
         f"[bold purple]Prophecy-build-tool[/bold purple] [bold black]"

--- a/src/pbt/__init__.py
+++ b/src/pbt/__init__.py
@@ -273,6 +273,45 @@ def test(path, driver_library_path, pipelines):
     pbt.test(driver_library_path, pipelines)
 
 
+@cli.command()
+@click.option(
+    "--path",
+    help="Path to the directory containing the pbt_project.yml file",
+    required=True,
+)
+@click.option(
+    "--bump",
+    type=click.Choice(['major', 'minor', 'patch'], case_sensitive=False),
+    help="bumps one of the semantic version numbers for the project and all pipelines based on the current value. "
+         "Only works if existing versions follow SemVer (MAJOR.MINOR.PATCH)",
+    required=False,
+)
+@click.option(
+    "--set",
+    type=str,
+    help="Explicitly set the exact version",
+    required=False,
+)
+@click.option(
+    "--force", "--spike",
+    default=False,
+    is_flag=True,
+    help="bypass errors if the version set is lower than the base branch",
+    required=False,
+)
+def versioning(path, _set, bump, force):
+    pbt = PBTCli.from_conf_folder(path)
+
+    if _set and bump:
+        raise click.UsageError("Options '--set' and '--bump' are mutually exclusive.")
+    elif _set:
+        pbt.project.version_set(_set, force)
+    elif bump:
+        pbt.project.version_bump(bump, force)
+    else:
+        raise click.UsageError("must give either '--set' or '--bump'")
+
+
 if __name__ == "pbt":
     print(
         f"[bold purple]Prophecy-build-tool[/bold purple] [bold black]"

--- a/src/pbt/__init__.py
+++ b/src/pbt/__init__.py
@@ -303,7 +303,7 @@ def test(path, driver_library_path, pipelines):
     "--sync",
     default=False,
     is_flag=True,
-    help="Ensure all files are set to the same version that is defined in pbt_project.yml",
+    help="Ensure all files are set to the same version that is defined in pbt_project.yml. (implies --force)",
     required=False,
 )
 def versioning(path, bump, set, force, sync):

--- a/src/pbt/__init__.py
+++ b/src/pbt/__init__.py
@@ -299,17 +299,26 @@ def test(path, driver_library_path, pipelines):
     help="bypass errors if the version set is lower than the base branch",
     required=False,
 )
-def versioning(path, bump, _set, force):
+@click.option(
+    "--sync",
+    default=False,
+    is_flag=True,
+    help="Ensure all files are set to the same version that is defined in pbt_project.yml",
+    required=False,
+)
+def versioning(path, bump, set, force, sync):
     pbt = PBTCli.from_conf_folder(path)
 
-    if _set and bump:
-        raise click.UsageError("Options '--set' and '--bump' are mutually exclusive.")
-    elif _set:
-        pbt.project.version_set(_set, force)
+    if sum([set is not None, bump is not None, sync]) > 1:
+        raise click.UsageError("Options '--set', '--bump', '--sync' are mutually exclusive.")
+    elif set:
+        pbt.version_set(set, force)
     elif bump:
-        pbt.project.version_bump(bump, force)
+        pbt.version_bump(bump, force)
+    elif sync:
+        pbt.version_set(None, force)
     else:
-        raise click.UsageError("must give either '--set' or '--bump'")
+        raise click.UsageError("must give ONE of: '--set', '--bump', '--sync'")
 
 
 @cli.command()

--- a/src/pbt/__init__.py
+++ b/src/pbt/__init__.py
@@ -281,9 +281,9 @@ def test(path, driver_library_path, pipelines):
 )
 @click.option(
     "--bump",
-    type=click.Choice(['major', 'minor', 'patch'], case_sensitive=False),
+    type=click.Choice(['major', 'minor', 'patch', 'build', 'prerelease'], case_sensitive=False),
     help="bumps one of the semantic version numbers for the project and all pipelines based on the current value. "
-         "Only works if existing versions follow SemVer (MAJOR.MINOR.PATCH)",
+         "Only works if existing versions follow semantic versioning https://semver.org/",
     required=False,
 )
 @click.option(
@@ -306,10 +306,16 @@ def test(path, driver_library_path, pipelines):
     help="Ensure all files are set to the same version that is defined in pbt_project.yml. (implies --force)",
     required=False,
 )
-def versioning(path, bump, set, force, sync):
+@click.option(
+    "--set-prerelease",
+    type=str,
+    help="Set a prerelease string. example '-SNAPSHOT' or '-rc.4'",
+    required=False,
+)
+def versioning(path, bump, set, force, sync, set_prerelease):
     pbt = PBTCli.from_conf_folder(path)
 
-    if sum([set is not None, bump is not None, sync]) > 1:
+    if sum([set is not None, bump is not None, sync, set_prerelease is not None]) > 1:
         raise click.UsageError("Options '--set', '--bump', '--sync' are mutually exclusive.")
     elif set:
         pbt.version_set(set, force)
@@ -317,8 +323,10 @@ def versioning(path, bump, set, force, sync):
         pbt.version_bump(bump, force)
     elif sync:
         pbt.version_set(None, force)
+    elif set_prerelease:
+        pbt.version_set_prerelease(set_prerelease, force)
     else:
-        raise click.UsageError("must give ONE of: '--set', '--bump', '--sync'")
+        raise click.UsageError("must give ONE of: '--set', '--bump', '--sync', --set-prerelease'")
 
 
 @cli.command()

--- a/src/pbt/__init__.py
+++ b/src/pbt/__init__.py
@@ -299,7 +299,7 @@ def test(path, driver_library_path, pipelines):
     help="bypass errors if the version set is lower than the base branch",
     required=False,
 )
-def versioning(path, _set, bump, force):
+def versioning(path, bump, _set, force):
     pbt = PBTCli.from_conf_folder(path)
 
     if _set and bump:
@@ -331,33 +331,24 @@ def versioning(path, _set, bump, force):
     required=False,
 )
 @click.option(
-    "--no-branch",
-    default=False,
-    is_flag=True,
-    help="normally the tag is prefixed with the branch name: <project_name>/<branch_name>/<version>. "
-         "This removes the <branch_name>.",
-    required=False,
-)
-@click.option(
-    "--no-project",
-    default=False,
-    is_flag=True,
-    help="normally the tag is prefixed with the branch name: <project_name>/<branch_name>/<version>. "
-         "This removes the <project_name>.",
+    "--branch",
+    default=None,
+    help="normally the tag is prefixed with the branch name: <branch_name>/<version>. "
+         "This overrides <branch_name>. Provide \"\" to omit the branch name.",
     required=False,
 )
 @click.option(
     "--custom",
-    default=False,
+    default=None,
     type=str,
     help="Explicitly set the exact tag using a string. Ignores other options.",
     required=False,
 )
-def tag(path, repo_path, no_push, no_branch, no_project, custom):
+def tag(path, repo_path, no_push, branch, custom):
     pbt = PBTCli.from_conf_folder(path)
     if not repo_path:
         repo_path = path
-    pbt.project.tag(repo_path, no_push=no_push, no_branch=no_branch, no_project=no_project, custom=custom)
+    pbt.tag(repo_path, no_push=no_push, branch=branch, custom=custom)
 
 
 if __name__ == "pbt":

--- a/src/pbt/pbt_cli.py
+++ b/src/pbt/pbt_cli.py
@@ -123,7 +123,7 @@ class PBTCli(object):
         # TODO need to be able to parse valid maven syntax and dbt syntax for versioning in addition to pep440
         try:
             v = parse_version(self.project.project.pbt_project_dict['version'])
-        except InvalidVersion as e:
+        except InvalidVersion:
             log(f"Error bumping: Unable to parse version {self.project.project.pbt_project_dict['version']}. "
                 f"Use PEP440")
             exit(1)
@@ -185,5 +185,4 @@ class PBTCli(object):
             # Pushing the tag to the remote repository
             origin = repo.remote(name='origin')
             origin.push(tag)
-            log(f"Pushing tag to remote")
-
+            log("Pushing tag to remote")

--- a/src/pbt/pbt_cli.py
+++ b/src/pbt/pbt_cli.py
@@ -119,6 +119,7 @@ class PBTCli(object):
         _replace_in_files(matching_regex, replacement_string, files_to_fix)
 
     def version_bump(self, bump_type, force):
+        # TODO need to be able to parse valid maven syntax and dbt syntax for versioning in addition to pep440
         try:
             v = parse_version(self.project.project.pbt_project_dict['version'])
         except InvalidVersion as e:
@@ -127,7 +128,7 @@ class PBTCli(object):
             exit(1)
 
         # Version is a final class and we cannot inherit/extend so we steal the string building logic from its
-        #  __str__() implementation:
+        #  __str__() implementation. this follows pep440:
         parts = []
         if v.epoch != 0:
             parts.append(f"{v.epoch}!")

--- a/src/pbt/pbt_cli.py
+++ b/src/pbt/pbt_cli.py
@@ -7,6 +7,9 @@ from .utils.project_config import ProjectConfig
 from packaging.version import parse as parse_version
 from .utility import custom_print as log
 import git
+import re
+import yaml
+import glob
 
 
 class PBTCli(object):
@@ -74,14 +77,48 @@ class PBTCli(object):
         self.project.validate(treat_warnings_as_errors)
 
     def update_all_versions(self, new_version, force):
-        orig_version = parse_version(self.project.project.pbt_project_dict['version'])
         # check this version against base branch if not "force". error if it is not greater
         if not force:
+            orig_version = parse_version(self.project.project.pbt_project_dict['version'])
             if parse_version(new_version) <= parse_version(orig_version):
                 raise ValueError(f"new version {new_version} is not later than {orig_version}")
 
-        # overwrite pbt_project.yml, all setup.py, all pom.xml
-        pass #TODO
+        # PBT project
+        pbt_project_file = os.path.join(self.project.project.project_path, "pbt_project.yml")
+        with open(pbt_project_file, 'r') as fd:
+            pbt_project = yaml.safe_load(fd.read())
+            pbt_project['version'] = new_version
+
+        with open(pbt_project_file, 'w') as fd:
+            fd.write(yaml.safe_dump(pbt_project))
+
+        # replace version in language specific files:
+        if self.project.project.project_language == 'python':
+            matching_regex = r"^\s*version\s*=\s*.*$"
+            replacement_string = f"    version = '{new_version}',"
+            filename_to_find = "setup.py"
+        elif self.project.project.project_language == 'scala':
+            matching_regex = r"^\s*<version>.*</version>"
+            replacement_string = f"    <version>{new_version}</version>"
+            filename_to_find = "pom.xml"
+        elif self.project.project.project_language == 'sql':
+            matching_regex = r"^version: .*$"
+            replacement_string = f"version: \"{new_version}\""
+            filename_to_find = "dbt_project.yml"
+        else:
+            raise ValueError("bad project language: ", self.project.project.project_language)
+
+        files_to_fix = glob.glob(os.path.join(self.project.project.project_path, '**', filename_to_find),
+                                 recursive=True)
+
+        for file in files_to_fix:
+            pattern = re.compile(matching_regex, re.MULTILINE)
+            with open(file, 'r') as fd:
+                content = fd.read()
+            # Replace the matching line with the new version line
+            new_content = pattern.sub(replacement_string, content)
+            with open(file, 'w') as fd:
+                fd.write(new_content)
 
     def version_bump(self, bump_type, force):
         new_version = parse_version(self.project.project.pbt_project_dict['version'])
@@ -95,12 +132,13 @@ class PBTCli(object):
         else:
             raise ValueError("bad choice for bump type: ", bump_type)
 
-        self.update_all_versions(new_version, force)
+        self.update_all_versions(str(new_version), force)
 
     def version_set(self, version, force):
-        new_version = parse_version(version)
-
-        self.update_all_versions(new_version, force)
+        if version is None:
+            # sync option will send None, so take existing version.
+            version = self.project.project.pbt_project_dict['version']
+        self.update_all_versions(version, force)
 
     def tag(self, repo_path, no_push=False, branch=None, custom=None):
         repo = git.Repo(repo_path)

--- a/src/pbt/pbt_cli.py
+++ b/src/pbt/pbt_cli.py
@@ -7,8 +7,8 @@ from .utils.project_config import ProjectConfig
 from packaging.version import InvalidVersion, parse as parse_version
 from .utility import custom_print as log
 import git
-import re
-import glob
+
+from .utils.versioning import update_all_versions, get_bumped_version
 
 
 class PBTCli(object):
@@ -75,95 +75,102 @@ class PBTCli(object):
     def validate(self, treat_warnings_as_errors: bool):
         self.project.validate(treat_warnings_as_errors)
 
-    def update_all_versions(self, new_version, force):
-        # check this version against base branch if not "force". error if it is not greater
-        if not force:
-            orig_version = self.project.project.pbt_project_dict['version']
-            if parse_version(new_version) <= parse_version(orig_version):
-                raise ValueError(f"new version {new_version} is not later than {orig_version}")
-
-        def _replace_in_files(matching_regex: str, replacement_string: str, files: list):
-            # NOTE: use this pattern matching rather than opening/rewriting files as yaml parsing may shuffle
-            #  line order and cause unnecessary changes.
-            for file in files:
-                pattern = re.compile(matching_regex, re.MULTILINE)
-                with open(file, 'r') as fd:
-                    content = fd.read()
-                # only replace the first instance of the version encountered. otherwise we risk
-                # replacing other versions (especially found in pom.xml)
-                new_content = pattern.sub(replacement_string, content, count=1)
-                with open(file, 'w') as fd:
-                    fd.write(new_content)
-
-        # PBT project
-        pbt_project_file = os.path.join(self.project.project.project_path, "pbt_project.yml")
-        _replace_in_files(r"^version: .*$", f"version: {new_version}", [pbt_project_file])
-
-        # replace version in language specific files:
-        if self.project.project.project_language == 'python':
-            matching_regex = r"^\s*version\s*=\s*.*$"
-            replacement_string = f"    version = '{new_version}',"
-            filename_to_find = "setup.py"
-        elif self.project.project.project_language == 'scala':
-            matching_regex = r"^\s*<version>.*</version>"
-            replacement_string = f"    <version>{new_version}</version>"
-            filename_to_find = "pom.xml"
-        elif self.project.project.project_language == 'sql':
-            matching_regex = r"^version: .*$"
-            replacement_string = f"version: \"{new_version}\""
-            filename_to_find = "dbt_project.yml"
-        else:
-            raise ValueError("bad project language: ", self.project.project.project_language)
-
-        files_to_fix = glob.glob(os.path.join(self.project.project.project_path, '**', filename_to_find),
-                                 recursive=True)
-        _replace_in_files(matching_regex, replacement_string, files_to_fix)
+    # def update_all_versions(self, new_version, force):
+    #     # check this version against base branch if not "force". error if it is not greater
+    #     if not force:
+    #         orig_version = self.project.project.pbt_project_dict['version']
+    #         if parse_version(new_version) <= parse_version(orig_version):
+    #             raise ValueError(f"new version {new_version} is not later than {orig_version}")
+    #
+    #     def _replace_in_files(matching_regex: str, replacement_string: str, files: list):
+    #         # NOTE: use this pattern matching rather than opening/rewriting files as yaml parsing may shuffle
+    #         #  line order and cause unnecessary changes.
+    #         for file in files:
+    #             pattern = re.compile(matching_regex, re.MULTILINE)
+    #             with open(file, 'r') as fd:
+    #                 content = fd.read()
+    #             # only replace the first instance of the version encountered. otherwise we risk
+    #             # replacing other versions (especially found in pom.xml)
+    #             new_content = pattern.sub(replacement_string, content, count=1)
+    #             with open(file, 'w') as fd:
+    #                 fd.write(new_content)
+    #
+    #     # PBT project
+    #     pbt_project_file = os.path.join(self.project.project.project_path, "pbt_project.yml")
+    #     _replace_in_files(r"^version: .*$", f"version: {new_version}", [pbt_project_file])
+    #
+    #     # replace version in language specific files:
+    #     if self.project.project.project_language == 'python':
+    #         matching_regex = r"^\s*version\s*=\s*.*$"
+    #         replacement_string = f"    version = '{new_version}',"
+    #         filename_to_find = "setup.py"
+    #     elif self.project.project.project_language == 'scala':
+    #         matching_regex = r"^\s*<version>.*</version>"
+    #         replacement_string = f"    <version>{new_version}</version>"
+    #         filename_to_find = "pom.xml"
+    #     elif self.project.project.project_language == 'sql':
+    #         matching_regex = r"^version: .*$"
+    #         replacement_string = f"version: \"{new_version}\""
+    #         filename_to_find = "dbt_project.yml"
+    #     else:
+    #         raise ValueError("bad project language: ", self.project.project.project_language)
+    #
+    #     files_to_fix = glob.glob(os.path.join(self.project.project.project_path, '**', filename_to_find),
+    #                              recursive=True)
+    #     _replace_in_files(matching_regex, replacement_string, files_to_fix)
 
     def version_bump(self, bump_type, force):
         # TODO need to be able to parse valid maven syntax and dbt syntax for versioning in addition to pep440
-        try:
-            v = parse_version(self.project.project.pbt_project_dict['version'])
-        except InvalidVersion:
-            log(f"Error bumping: Unable to parse version {self.project.project.pbt_project_dict['version']}. "
-                f"Use PEP440")
-            exit(1)
+        # try:
+        #     v = parse_version(self.project.project.pbt_project_dict['version'])
+        # except InvalidVersion:
+        #     log(f"Error bumping: Unable to parse version {self.project.project.pbt_project_dict['version']}. "
+        #         f"Use PEP440")
+        #     exit(1)
+        #
+        # if bump_type == 'major':
+        #     major = v.major + 1
+        #     minor = 0
+        #     micro = 0
+        # elif bump_type == 'minor':
+        #     major = v.major
+        #     minor = v.minor + 1
+        #     micro = 0
+        # elif bump_type == 'patch':
+        #     major = v.major
+        #     minor = v.minor
+        #     micro = v.micro + 1
+        # # Version is a final class and we cannot inherit/extend so we steal the string building logic from its
+        # #  __str__() implementation. this follows pep440:
+        # parts = []
+        # if v.epoch != 0:
+        #     parts.append(f"{v.epoch}!")
+        # parts.append(f"{major}.{minor}.{micro}")
+        # if v.pre is not None:
+        #     parts.append("".join(str(x) for x in v.pre))
+        # if v.post is not None:
+        #     parts.append(f".post{v.post}")
+        # if v.dev is not None:
+        #     parts.append(f".dev{v.dev}")
+        # if v.local is not None:
+        #     parts.append(f"+{v.local}")
+        # new_version = "".join(parts)
+        new_version = get_bumped_version(self.project.project.pbt_project_dict['version'], bump_type, force)
 
-        if bump_type == 'major':
-            major = v.major + 1
-            minor = 0
-            micro = 0
-        elif bump_type == 'minor':
-            major = v.major
-            minor = v.minor + 1
-            micro = 0
-        elif bump_type == 'patch':
-            major = v.major
-            minor = v.minor
-            micro = v.micro + 1
-        # Version is a final class and we cannot inherit/extend so we steal the string building logic from its
-        #  __str__() implementation. this follows pep440:
-        parts = []
-        if v.epoch != 0:
-            parts.append(f"{v.epoch}!")
-        parts.append(f"{major}.{minor}.{micro}")
-        if v.pre is not None:
-            parts.append("".join(str(x) for x in v.pre))
-        if v.post is not None:
-            parts.append(f".post{v.post}")
-        if v.dev is not None:
-            parts.append(f".dev{v.dev}")
-        if v.local is not None:
-            parts.append(f"+{v.local}")
-        new_version = "".join(parts)
-
-        self.update_all_versions(new_version, force)
+        update_all_versions(self.project.project.project_path,
+                            self.project.project.pbt_project_dict['language'],
+                            orig_project_version=self.project.project.pbt_project_dict['version'],
+                            new_version=new_version, force=force)
 
     def version_set(self, version, force):
         if version is None:
             # sync option will send None, so take existing version.
             version = self.project.project.pbt_project_dict['version']
             force = True
-        self.update_all_versions(version, force)
+        update_all_versions(self.project.project.project_path,
+                            self.project.project.pbt_project_dict['language'],
+                            orig_project_version=self.project.project.pbt_project_dict['version'],
+                            new_version=version, force=force)
 
     def tag(self, repo_path, no_push=False, branch=None, custom=None):
         repo = git.Repo(repo_path)

--- a/src/pbt/pbt_cli.py
+++ b/src/pbt/pbt_cli.py
@@ -4,6 +4,8 @@ from typing import Optional
 from .deployment.project import ProjectDeployment
 from .entities.project import Project
 from .utils.project_config import ProjectConfig
+from packaging.version import parse as parse_version
+import copy
 
 
 class PBTCli(object):
@@ -69,3 +71,33 @@ class PBTCli(object):
 
     def validate(self, treat_warnings_as_errors: bool):
         self.project.validate(treat_warnings_as_errors)
+
+    def update_all_versions(self, new_version, force):
+        orig_version = parse_version(self.project.project.pbt_project_dict['version'])
+        # check this version against base branch if not "force". error if it is not greater
+        if not force:
+            if parse_version(new_version) <= parse_version(orig_version):
+                raise ValueError(f"new version {new_version} is not later than {orig_version}")
+
+        # overwrite pbt_project.yml, all setup.py, all pom.xml
+        pass #TODO
+
+    def version_bump(self, bump_type, force):
+        new_version = parse_version(self.project.project.pbt_project_dict['version'])
+
+        if bump_type == 'major':
+            new_version.major += 1
+        elif bump_type == 'minor':
+            new_version.minor += 1
+        elif bump_type == 'patch':
+            new_version.micro += 1
+        else:
+            raise ValueError("bad choice for bump type: ", bump_type)
+
+        self.update_all_versions(new_version, force)
+
+    def version_set(self, version, force):
+        new_version = parse_version(version)
+
+        self.update_all_versions(new_version, force)
+

--- a/src/pbt/pbt_cli.py
+++ b/src/pbt/pbt_cli.py
@@ -89,8 +89,9 @@ class PBTCli(object):
                 pattern = re.compile(matching_regex, re.MULTILINE)
                 with open(file, 'r') as fd:
                     content = fd.read()
-                    # Replace the matching line with the new version line
-                new_content = pattern.sub(replacement_string, content)
+                # only replace the first instance of the version encountered. otherwise we risk
+                # replacing other versions (especially found in pom.xml)
+                new_content = pattern.sub(replacement_string, content, count=1)
                 with open(file, 'w') as fd:
                     fd.write(new_content)
 

--- a/src/pbt/pbt_cli.py
+++ b/src/pbt/pbt_cli.py
@@ -128,14 +128,23 @@ class PBTCli(object):
                 f"Use PEP440")
             exit(1)
 
+        if bump_type == 'major':
+            major = v.major + 1
+            minor = 0
+            micro = 0
+        elif bump_type == 'minor':
+            major = v.major
+            minor = v.minor + 1
+            micro = 0
+        elif bump_type == 'patch':
+            major = v.major
+            minor = v.minor
+            micro = v.micro + 1
         # Version is a final class and we cannot inherit/extend so we steal the string building logic from its
         #  __str__() implementation. this follows pep440:
         parts = []
         if v.epoch != 0:
             parts.append(f"{v.epoch}!")
-        major = v.major + 1 if bump_type == 'major' else v.major
-        minor = v.minor + 1 if bump_type == 'minor' else v.minor
-        micro = v.micro + 1 if bump_type == 'micro' else v.micro
         parts.append(f"{major}.{minor}.{micro}")
         if v.pre is not None:
             parts.append("".join(str(x) for x in v.pre))

--- a/src/pbt/pbt_cli.py
+++ b/src/pbt/pbt_cli.py
@@ -5,7 +5,7 @@ from .deployment.project import ProjectDeployment
 from .entities.project import Project
 from .utils.project_config import ProjectConfig
 from packaging.version import parse as parse_version
-import copy
+from .utility import custom_print as log
 import git
 
 
@@ -102,17 +102,19 @@ class PBTCli(object):
 
         self.update_all_versions(new_version, force)
 
-    def tag(self, repo_path, no_push=False, custom=None, no_branch=False, no_project=False):
+    def tag(self, repo_path, no_push=False, branch=None, custom=None):
         repo = git.Repo(repo_path)
 
         if custom:
             tag = custom
         else:
             tag = self.project.project.pbt_project_dict['version']
-            if not no_branch:
-                tag = repo.active_branch + "/" + tag
-            if not no_project:
-                tag = self.project.project.pbt_project_dict['name'] + "/" + tag
+            if branch is None:
+                tag = repo.active_branch.name + "/" + tag
+            elif branch != "":
+                tag = branch + "/" + tag
+
+        log(f"Setting tag to: {tag}")
 
         repo.create_tag(tag)
 
@@ -120,4 +122,5 @@ class PBTCli(object):
             # Pushing the tag to the remote repository
             origin = repo.remote(name='origin')
             origin.push(tag)
+            log(f"Pushing tag to remote")
 

--- a/src/pbt/pbt_cli.py
+++ b/src/pbt/pbt_cli.py
@@ -6,6 +6,7 @@ from .entities.project import Project
 from .utils.project_config import ProjectConfig
 from packaging.version import parse as parse_version
 import copy
+import git
 
 
 class PBTCli(object):
@@ -100,4 +101,23 @@ class PBTCli(object):
         new_version = parse_version(version)
 
         self.update_all_versions(new_version, force)
+
+    def tag(self, repo_path, no_push=False, custom=None, no_branch=False, no_project=False):
+        repo = git.Repo(repo_path)
+
+        if custom:
+            tag = custom
+        else:
+            tag = self.project.project.pbt_project_dict['version']
+            if not no_branch:
+                tag = repo.active_branch + "/" + tag
+            if not no_project:
+                tag = self.project.project.pbt_project_dict['name'] + "/" + tag
+
+        repo.create_tag(tag)
+
+        if not no_push:
+            # Pushing the tag to the remote repository
+            origin = repo.remote(name='origin')
+            origin.push(tag)
 

--- a/src/pbt/utils/versioning.py
+++ b/src/pbt/utils/versioning.py
@@ -1,6 +1,6 @@
 import os
 import re
-from packaging.version as packaging_version
+from packaging import version as packaging_version
 import semver
 import glob
 from ..utility import custom_print as log
@@ -10,7 +10,8 @@ def update_all_versions(project_path, project_language, orig_project_version, ne
     # check this version against base branch if not "force". error if it is not greater
     if not force:
         orig_version = orig_project_version
-        if parse_version(new_version) <= parse_version(orig_version):
+        if semver.parse_version_info(new_version) <= semver.parse_version_info(orig_version):
+            log(f"new version {new_version} is not later than {orig_version}")
             raise ValueError(f"new version {new_version} is not later than {orig_version}")
 
     def _replace_in_files(matching_regex: str, replacement_string: str, files: list):
@@ -51,110 +52,33 @@ def update_all_versions(project_path, project_language, orig_project_version, ne
     _replace_in_files(matching_regex, replacement_string, files_to_fix)
 
 
-def get_bumped_version_python(original_version, bump_type):
-    try:
-        v = parse_version(original_version)
-    except InvalidVersion:
-        log(f"Error bumping: Unable to parse version {original_version}. "
-            f"Use PEP440")
-        exit(1)
-
-    if bump_type == 'major':
-        major = v.major + 1
-        minor = 0
-        micro = 0
-    elif bump_type == 'minor':
-        major = v.major
-        minor = v.minor + 1
-        micro = 0
-    elif bump_type == 'patch':
-        major = v.major
-        minor = v.minor
-        micro = v.micro + 1
-    # Version is a final class and we cannot inherit/extend so we steal the string building logic from its
-    #  __str__() implementation. this follows pep440:
-    parts = []
-    if v.epoch != 0:
-        parts.append(f"{v.epoch}!")
-    parts.append(f"{major}.{minor}.{micro}")
-    if v.pre is not None:
-        parts.append("".join(str(x) for x in v.pre))
-    if v.post is not None:
-        parts.append(f".post{v.post}")
-    if v.dev is not None:
-        parts.append(f".dev{v.dev}")
-    if v.local is not None:
-        parts.append(f"+{v.local}")
-    new_version = "".join(parts)
-
-    return new_version
-
-
-def get_bumped_version_scala(original_version, bump_type):
-    try:
-        v = semver.parse_version_info(original_version)
-    except InvalidVersion:
-        log(f"Error bumping: Unable to parse version {original_version}. "
-            f"Must Use Semantic Versioning")
-        exit(1)
-
-    if bump_type == 'major':
-        v.bump_major()
-    elif bump_type == 'minor':
-        v.bump_minor()
-    elif bump_type == 'patch':
-        v.bump_patch()
-    elif bump_type == 'build':
-        v.bump_build()
-    elif bump_type == 'prerelease':
-        v.bump_prerelease()
-
-    return str(v)
-
-
-def get_bumped_version_sql(original_version, bump_type):
-    # tODo check if dbt has a standard, otherwise use python
-    return get_bumped_version_scala(original_version, bump_type)
-
-
 def get_bumped_version(original_version, bump_type, project_language):
-    # replace version in language specific files:
-
     try:
         v = semver.parse_version_info(original_version)
-    except InvalidVersion:
+    except ValueError:
         log(f"Error bumping: Unable to parse version {original_version}. "
             f"Must Use Semantic Versioning")
         exit(1)
 
     if project_language == 'python':
+        # add an extra check for python as python packages should conform to PEP440 standard and be parseable by
+        # the `packaging` package
         try:
             packaging_version.parse(original_version)
-        except InvalidVersion:
+        except packaging_version.InvalidVersion:
             log(f"Error bumping: Unable to parse version {original_version}. "
                 f"Use PEP440")
             exit(1)
 
     if bump_type == 'major':
-        v.bump_major()
+        v = v.bump_major()
     elif bump_type == 'minor':
-        v.bump_minor()
+        v = v.bump_minor()
     elif bump_type == 'patch':
-        v.bump_patch()
+        v = v.bump_patch()
     elif bump_type == 'build':
-        v.bump_build()
+        v = v.bump_build()
     elif bump_type == 'prerelease':
-        v.bump_prerelease()
+        v = v.bump_prerelease()
 
     return str(v)
-
-    if project_language == 'python':
-        new_version = get_bumped_version_python(original_version, bump_type)
-    elif project_language == 'scala':
-        new_version = get_bumped_version_scala(original_version, bump_type)
-    elif project_language == 'sql':
-        new_version = get_bumped_version_sql(original_version, bump_type)
-    else:
-        raise ValueError("bad project language: ", project_language)
-
-    return new_version

--- a/src/pbt/utils/versioning.py
+++ b/src/pbt/utils/versioning.py
@@ -1,0 +1,160 @@
+import os
+import re
+from packaging.version as packaging_version
+import semver
+import glob
+from ..utility import custom_print as log
+
+
+def update_all_versions(project_path, project_language, orig_project_version, new_version, force):
+    # check this version against base branch if not "force". error if it is not greater
+    if not force:
+        orig_version = orig_project_version
+        if parse_version(new_version) <= parse_version(orig_version):
+            raise ValueError(f"new version {new_version} is not later than {orig_version}")
+
+    def _replace_in_files(matching_regex: str, replacement_string: str, files: list):
+        # NOTE: use this pattern matching rather than opening/rewriting files as yaml parsing may shuffle
+        #  line order and cause unnecessary changes.
+        for file in files:
+            pattern = re.compile(matching_regex, re.MULTILINE)
+            with open(file, 'r') as fd:
+                content = fd.read()
+            # only replace the first instance of the version encountered. otherwise we risk
+            # replacing other versions (especially found in pom.xml)
+            new_content = pattern.sub(replacement_string, content, count=1)
+            with open(file, 'w') as fd:
+                fd.write(new_content)
+
+    # PBT project
+    pbt_project_file = os.path.join(project_path, "pbt_project.yml")
+    _replace_in_files(r"^version: .*$", f"version: {new_version}", [pbt_project_file])
+
+    # replace version in language specific files:
+    if project_language == 'python':
+        matching_regex = r"^\s*version\s*=\s*.*$"
+        replacement_string = f"    version = '{new_version}',"
+        filename_to_find = "setup.py"
+    elif project_language == 'scala':
+        matching_regex = r"^\s*<version>.*</version>"
+        replacement_string = f"    <version>{new_version}</version>"
+        filename_to_find = "pom.xml"
+    elif project_language == 'sql':
+        matching_regex = r"^version: .*$"
+        replacement_string = f"version: \"{new_version}\""
+        filename_to_find = "dbt_project.yml"
+    else:
+        raise ValueError("bad project language: ", project_language)
+
+    files_to_fix = glob.glob(os.path.join(project_path, '**', filename_to_find),
+                             recursive=True)
+    _replace_in_files(matching_regex, replacement_string, files_to_fix)
+
+
+def get_bumped_version_python(original_version, bump_type):
+    try:
+        v = parse_version(original_version)
+    except InvalidVersion:
+        log(f"Error bumping: Unable to parse version {original_version}. "
+            f"Use PEP440")
+        exit(1)
+
+    if bump_type == 'major':
+        major = v.major + 1
+        minor = 0
+        micro = 0
+    elif bump_type == 'minor':
+        major = v.major
+        minor = v.minor + 1
+        micro = 0
+    elif bump_type == 'patch':
+        major = v.major
+        minor = v.minor
+        micro = v.micro + 1
+    # Version is a final class and we cannot inherit/extend so we steal the string building logic from its
+    #  __str__() implementation. this follows pep440:
+    parts = []
+    if v.epoch != 0:
+        parts.append(f"{v.epoch}!")
+    parts.append(f"{major}.{minor}.{micro}")
+    if v.pre is not None:
+        parts.append("".join(str(x) for x in v.pre))
+    if v.post is not None:
+        parts.append(f".post{v.post}")
+    if v.dev is not None:
+        parts.append(f".dev{v.dev}")
+    if v.local is not None:
+        parts.append(f"+{v.local}")
+    new_version = "".join(parts)
+
+    return new_version
+
+
+def get_bumped_version_scala(original_version, bump_type):
+    try:
+        v = semver.parse_version_info(original_version)
+    except InvalidVersion:
+        log(f"Error bumping: Unable to parse version {original_version}. "
+            f"Must Use Semantic Versioning")
+        exit(1)
+
+    if bump_type == 'major':
+        v.bump_major()
+    elif bump_type == 'minor':
+        v.bump_minor()
+    elif bump_type == 'patch':
+        v.bump_patch()
+    elif bump_type == 'build':
+        v.bump_build()
+    elif bump_type == 'prerelease':
+        v.bump_prerelease()
+
+    return str(v)
+
+
+def get_bumped_version_sql(original_version, bump_type):
+    # tODo check if dbt has a standard, otherwise use python
+    return get_bumped_version_scala(original_version, bump_type)
+
+
+def get_bumped_version(original_version, bump_type, project_language):
+    # replace version in language specific files:
+
+    try:
+        v = semver.parse_version_info(original_version)
+    except InvalidVersion:
+        log(f"Error bumping: Unable to parse version {original_version}. "
+            f"Must Use Semantic Versioning")
+        exit(1)
+
+    if project_language == 'python':
+        try:
+            packaging_version.parse(original_version)
+        except InvalidVersion:
+            log(f"Error bumping: Unable to parse version {original_version}. "
+                f"Use PEP440")
+            exit(1)
+
+    if bump_type == 'major':
+        v.bump_major()
+    elif bump_type == 'minor':
+        v.bump_minor()
+    elif bump_type == 'patch':
+        v.bump_patch()
+    elif bump_type == 'build':
+        v.bump_build()
+    elif bump_type == 'prerelease':
+        v.bump_prerelease()
+
+    return str(v)
+
+    if project_language == 'python':
+        new_version = get_bumped_version_python(original_version, bump_type)
+    elif project_language == 'scala':
+        new_version = get_bumped_version_scala(original_version, bump_type)
+    elif project_language == 'sql':
+        new_version = get_bumped_version_sql(original_version, bump_type)
+    else:
+        raise ValueError("bad project language: ", project_language)
+
+    return new_version

--- a/test/resources/HelloWorld/pbt_project.yml
+++ b/test/resources/HelloWorld/pbt_project.yml
@@ -1,6 +1,6 @@
 name: HelloWorld
 description: ''
-version: 0.0.1-SNAPSHOT
+version: 0.0.1
 author: ashish@prophecy.io
 language: python
 buildSystem: ''

--- a/test/test_tagging.py
+++ b/test/test_tagging.py
@@ -1,0 +1,87 @@
+import unittest
+from click.testing import CliRunner
+from src.pbt import tag
+import os
+import shutil
+import uuid
+from git import Repo
+
+CURRENT_DIRECTORY = os.path.dirname(os.path.abspath(__file__))
+REPO_PATH = os.path.dirname(CURRENT_DIRECTORY)
+RESOURCES_PATH = os.path.join(CURRENT_DIRECTORY, "resources")
+SAMPLE_REPO = "https://github.com/prophecy-samples/HelloProphecy.git"
+
+
+class TaggingTestCase(unittest.TestCase):
+
+    @staticmethod
+    def _get_tmp_sample_repo(repo_url=SAMPLE_REPO):
+        new_path = os.path.join("/tmp/", SAMPLE_REPO.split("/")[-1], f"-{uuid.uuid4()}")
+        repo = Repo.clone_from(repo_url, new_path)
+        return repo, new_path
+
+    def setUp(self):
+        self.repo, self.repo_path = TaggingTestCase._get_tmp_sample_repo()
+        self.python_project_path = os.path.join(self.repo_path, "prophecy")
+        self.python_project_path = os.path.join(self.repo_path, "prophecy_scala")
+
+    def tearDown(self):
+        if self.repo_path:
+            shutil.rmtree(self.repo_path)
+
+    @staticmethod
+    def _get_pbt_version(path_to_project):
+        with open(os.path.join(path_to_project, "pbt_project.yml"), 'r') as fd:
+            for line in fd:
+                if line.startswith("version: "):
+                    return line.split(":")[1].strip()
+
+    def test_tagging_custom(self):
+        project_path = self.python_project_path
+
+        custom_tag = "CUSTOM_TAG_UNITTEST"
+        runner = CliRunner()
+        result = runner.invoke(tag, ["--path", project_path, "--repo-path", self.repo_path,
+                                     "--no-push", "--custom", custom_tag])
+        assert result.exit_code == 0
+        assert custom_tag in self.repo.tags
+
+    def test_tagging_default(self):
+        project_path = self.python_project_path
+        pbt_version = TaggingTestCase._get_pbt_version(project_path)
+
+        branch_name = "custom_branch_unittest"
+        new_branch = self.repo.create_head(branch_name)
+        new_branch.checkout()
+
+        custom_tag = f"{branch_name}/{pbt_version}"
+        runner = CliRunner()
+        result = runner.invoke(tag, ["--path", project_path, "--repo-path", self.repo_path,
+                                     "--no-push"])
+        assert result.exit_code == 0
+
+        self.repo.tags
+        assert custom_tag in [str(t) for t in self.repo.tags]
+
+    def test_tagging_omit_branchname(self):
+        project_path = self.python_project_path
+        pbt_version = TaggingTestCase._get_pbt_version(project_path)
+
+        custom_tag = f"{pbt_version}"
+        runner = CliRunner()
+        result = runner.invoke(tag, ["--path", project_path, "--repo-path", self.repo_path,
+                                     "--no-push", "--branch", ""])
+        assert result.exit_code == 0
+        assert custom_tag in [str(t) for t in self.repo.tags]
+
+    def test_tagging_custom_branchname(self):
+        project_path = self.python_project_path
+        pbt_version = TaggingTestCase._get_pbt_version(project_path)
+
+        custom_branch_name = "nonexistant_branch"
+        custom_tag = f"{custom_branch_name}/{pbt_version}"
+        runner = CliRunner()
+        result = runner.invoke(tag, ["--path", project_path, "--repo-path", self.repo_path,
+                                     "--no-push", "--branch", custom_branch_name])
+        assert result.exit_code == 0
+        assert custom_tag in [str(t) for t in self.repo.tags]

--- a/test/test_versioning.py
+++ b/test/test_versioning.py
@@ -5,11 +5,13 @@ import os
 import git
 import glob
 import shutil
+from parameterized import parameterized
 
 
 CURRENT_DIRECTORY = os.path.dirname(os.path.abspath(__file__))
 REPO_PATH = os.path.dirname(CURRENT_DIRECTORY)
-PROJECT_PATH = CURRENT_DIRECTORY + "/test/resources/HelloWorld"
+PROJECT_PATH = CURRENT_DIRECTORY + "/resources/HelloWorld"
+PROJECTS_TO_TEST = [("HelloWorld"), ("BaseDirectory"), ("ProjectCreatedOn160523")]
 
 
 class VersioningTestCase(unittest.TestCase):
@@ -21,8 +23,8 @@ class VersioningTestCase(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         # Reset all changes in the 'test/' directory
-        cls.reset_changed_files('test/')
-        #cls.remove_build_dirs()
+        cls.reset_changed_files('test/resources/')
+        cls.remove_tmp_dirs()
 
     @classmethod
     def reset_changed_files(cls, directory):
@@ -38,23 +40,33 @@ class VersioningTestCase(unittest.TestCase):
             print("No files were changed.")
 
     @classmethod
-    def remove_build_dirs(cls):
-        build_dirs = glob.glob(os.path.join(PROJECT_PATH, '**', "build"))
-        for dir in build_dirs:
-            if os.path.exists(dir):
-                print("hi")
-                #shutil.rmtree(dir)
+    def remove_tmp_dirs(cls):
+        tmp_dirs = glob.glob(os.path.join(PROJECT_PATH, '**', "dist"), recursive=True) + \
+                        glob.glob(os.path.join(PROJECT_PATH, '**', "build"), recursive=True)
+        for d in tmp_dirs:
+            if os.path.exists(d):
+                shutil.rmtree(d)
 
+    @staticmethod
+    def _get_pbt_version(path_to_project):
+        with open(os.path.join(path_to_project, "pbt_project.yml"), 'r') as fd:
+            for line in fd:
+                if line.startswith("version: "):
+                    return line.split(":")[1].strip()
 
-    def test_versioning_sync_python():
+    @parameterized.expand([("HelloWorld"), ("BaseDirectory"), ("ProjectCreatedOn160523")])
+    def test_versioning_sync_python(self, project_name):
+        project_path = CURRENT_DIRECTORY + f"/resources/{project_name}"
+        pbt_version = VersioningTestCase._get_pbt_version(project_path)
+
         runner = CliRunner()
-        result = runner.invoke(versioning, ["--path", PROJECT_PATH, '--sync'])
+        result = runner.invoke(versioning, ["--path", project_path, '--sync'])
         assert result.exit_code == 0
 
-        result = runner.invoke(build_v2, ["--path", PROJECT_PATH])
+        result = runner.invoke(build_v2, ["--path", project_path])
         assert result.exit_code == 0
         # Find all .whl files in the current directory
-        whl_files = glob.glob(os.path.join(PROJECT_PATH, "**", '*.whl'))
-        for file_name in whl_files:
-            assert "-1.0-py3-none-any" not in file_name
+        whl_files = glob.glob(os.path.join(project_path, "**", '*.whl'))
+        # for file_name in whl_files:
+        #     assert f"-{pbt_version}-py3-none-any" in file_name
 

--- a/test/test_versioning.py
+++ b/test/test_versioning.py
@@ -7,12 +7,12 @@ import glob
 import shutil
 from parameterized import parameterized
 
-
 CURRENT_DIRECTORY = os.path.dirname(os.path.abspath(__file__))
 REPO_PATH = os.path.dirname(CURRENT_DIRECTORY)
 PROJECT_PATH = CURRENT_DIRECTORY + "/resources/HelloWorld"
-PROJECTS_TO_TEST = [("HelloWorld"), ("BaseDirectory"), ("ProjectCreatedOn160523")]
+PROJECTS_TO_TEST = ["HelloWorld", "BaseDirectory", "ProjectCreatedOn160523"]
 RESOURCES_PATH = os.path.join(CURRENT_DIRECTORY, "resources")
+
 
 class VersioningTestCase(unittest.TestCase):
     @classmethod
@@ -24,7 +24,7 @@ class VersioningTestCase(unittest.TestCase):
     def tearDown(cls):
         # Reset all changes in the 'test/' directory
         cls.reset_changed_files('test/resources/')
-        cls.remove_tmp_dirs()
+        VersioningTestCase._remove_tmp_dirs()
 
     @classmethod
     def reset_changed_files(cls, directory):
@@ -39,8 +39,8 @@ class VersioningTestCase(unittest.TestCase):
         else:
             print("No files were changed.")
 
-    @classmethod
-    def remove_tmp_dirs(cls):
+    @staticmethod
+    def _remove_tmp_dirs():
         tmp_dirs = ["dist", "build", "target"]
         for t in tmp_dirs:
             dirs_to_clean = glob.glob(os.path.join(RESOURCES_PATH, '**', t), recursive=True)
@@ -83,6 +83,9 @@ class VersioningTestCase(unittest.TestCase):
 
         result = runner.invoke(build_v2, ["--path", project_path])
         assert result.exit_code == 0
+
+        # future TODO; building the artifacts is kind of lazy and causes dependency on buildv2 command.
+        #              later on we should use a different mechanism to verify versions were correctly changed.
 
         # Find any .whl files in the current directory
         whl_files = glob.glob(os.path.join(project_path, "**", '*.whl'), recursive=True)

--- a/test/test_versioning.py
+++ b/test/test_versioning.py
@@ -1,0 +1,60 @@
+import unittest
+from click.testing import CliRunner
+from src.pbt import versioning, build_v2
+import os
+import git
+import glob
+import shutil
+
+
+CURRENT_DIRECTORY = os.path.dirname(os.path.abspath(__file__))
+REPO_PATH = os.path.dirname(CURRENT_DIRECTORY)
+PROJECT_PATH = CURRENT_DIRECTORY + "/test/resources/HelloWorld"
+
+
+class VersioningTestCase(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        # Initialize the repo object and set it as a class attribute
+        cls.repo = git.Repo(os.getcwd())  # Change this to your repo path
+
+    @classmethod
+    def tearDownClass(cls):
+        # Reset all changes in the 'test/' directory
+        cls.reset_changed_files('test/')
+        #cls.remove_build_dirs()
+
+    @classmethod
+    def reset_changed_files(cls, directory):
+        # Get a list of all changed files in the specified directory
+        changed_files = [item.a_path for item in cls.repo.index.diff(None) if item.a_path.startswith(directory)]
+
+        # Check if there are any changed files
+        if changed_files:
+            # Restore the changes to the working directory
+            cls.repo.git.checkout('--', *changed_files)
+            print(f"Reset changed files: {changed_files}")
+        else:
+            print("No files were changed.")
+
+    @classmethod
+    def remove_build_dirs(cls):
+        build_dirs = glob.glob(os.path.join(PROJECT_PATH, '**', "build"))
+        for dir in build_dirs:
+            if os.path.exists(dir):
+                print("hi")
+                #shutil.rmtree(dir)
+
+
+    def test_versioning_sync_python():
+        runner = CliRunner()
+        result = runner.invoke(versioning, ["--path", PROJECT_PATH, '--sync'])
+        assert result.exit_code == 0
+
+        result = runner.invoke(build_v2, ["--path", PROJECT_PATH])
+        assert result.exit_code == 0
+        # Find all .whl files in the current directory
+        whl_files = glob.glob(os.path.join(PROJECT_PATH, "**", '*.whl'))
+        for file_name in whl_files:
+            assert "-1.0-py3-none-any" not in file_name
+

--- a/test/test_versioning.py
+++ b/test/test_versioning.py
@@ -21,7 +21,7 @@ class VersioningTestCase(unittest.TestCase):
         cls.repo = git.Repo(os.getcwd())  # Change this to your repo path
 
     @classmethod
-    def tearDownClass(cls):
+    def tearDown(cls):
         # Reset all changes in the 'test/' directory
         cls.reset_changed_files('test/resources/')
         cls.remove_tmp_dirs()
@@ -67,9 +67,6 @@ class VersioningTestCase(unittest.TestCase):
         runner = CliRunner()
         result = runner.invoke(versioning, ["--path", project_path, "--bump", bump_type])
         assert result.exit_code == 0
-
-        #TODO teardown not being called after each parameterized call.
-        # ditch parameterize and just make non test_ classes
 
         new_pbt_version = VersioningTestCase._get_pbt_version(project_path)
         assert new_pbt_version != pbt_version

--- a/test/test_versioning.py
+++ b/test/test_versioning.py
@@ -97,8 +97,26 @@ class VersioningTestCase(unittest.TestCase):
         # make sure that we at least found *some* build artifacts:
         assert len(list(whl_files) + list(jar_files)) > 0
 
-    def test_versioning_version_error_no_force(self):
+    def test_versioning_version_set_below_no_force(self):
         project_path = os.path.join(RESOURCES_PATH, "HelloWorld")
         runner = CliRunner()
         result = runner.invoke(versioning, ["--path", project_path, '--set', "0.0.0"])
         assert result.exit_code == 1
+
+    def test_versioning_version_set_below_force(self):
+        project_path = os.path.join(RESOURCES_PATH, "HelloWorld")
+        runner = CliRunner()
+        result = runner.invoke(versioning, ["--path", project_path, '--set', "invalid-0.0.0-thing", "--force"])
+        assert result.exit_code == 0
+
+        new_pbt_version = VersioningTestCase._get_pbt_version(project_path)
+        assert new_pbt_version == "invalid-0.0.0-thing"
+
+    def test_versioning_version_set(self):
+        project_path = os.path.join(RESOURCES_PATH, "HelloWorld")
+        runner = CliRunner()
+        result = runner.invoke(versioning, ["--path", project_path, '--set', "999999.0.0"])
+        assert result.exit_code == 0
+
+        new_pbt_version = VersioningTestCase._get_pbt_version(project_path)
+        assert new_pbt_version == "999999.0.0"

--- a/test/test_versioning.py
+++ b/test/test_versioning.py
@@ -55,6 +55,26 @@ class VersioningTestCase(unittest.TestCase):
                 if line.startswith("version: "):
                     return line.split(":")[1].strip()
 
+    @parameterized.expand([
+        ("major", "1.0.0"),
+        ("minor", "0.1.0"),
+        ("patch", "0.0.2"),
+    ])
+    def test_versioning_bump_major_python(self, bump_type, version_result):
+        project_path = os.path.join(RESOURCES_PATH, "HelloWorld")
+        pbt_version = VersioningTestCase._get_pbt_version(project_path)
+
+        runner = CliRunner()
+        result = runner.invoke(versioning, ["--path", project_path, "--bump", bump_type])
+        assert result.exit_code == 0
+
+        #TODO teardown not being called after each parameterized call.
+        # ditch parameterize and just make non test_ classes
+
+        new_pbt_version = VersioningTestCase._get_pbt_version(project_path)
+        assert new_pbt_version != pbt_version
+        assert new_pbt_version == version_result
+
     @parameterized.expand(PROJECTS_TO_TEST)
     def test_versioning_sync_python(self, project_name):
         project_path = os.path.join(RESOURCES_PATH, project_name)
@@ -75,11 +95,10 @@ class VersioningTestCase(unittest.TestCase):
         # Find any .jar files in the current directory
         jar_files = glob.glob(os.path.join(project_path, "**", '*.jar'), recursive=True)
         for file_name in jar_files:
-            assert f"-{pbt_version}" in file_name
+            assert f"{pbt_version}" in file_name
 
         # make sure that we at least found *some* build artifacts:
         assert len(list(whl_files) + list(jar_files)) > 0
-
 
     def test_versioning_version_error_no_force(self):
         project_path = os.path.join(RESOURCES_PATH, "HelloWorld")


### PR DESCRIPTION
adding versioning and tagging tools to PBT to help for external CI/CD users. This will help change versions in all correct places for a given project language (pbt_project.yml, dbt_project.yml, setup.py, pom.xml). This will enable users to produce artifacts with the same version as their project.

```
Usage: pbt versioning [OPTIONS]

Options:
  --path TEXT                 Path to the directory containing the
                              pbt_project.yml file  [required]
  --bump [major|minor|patch]  bumps one of the semantic version numbers for
                              the project and all pipelines based on the
                              current value. Only works if existing versions
                              follow SemVer (MAJOR.MINOR.PATCH)
  --set TEXT                  Explicitly set the exact version
  --force, --spike            bypass errors if the version set is lower than
                              the base branch
  --sync                      Ensure all files are set to the same version
                              that is defined in pbt_project.yml. (implies
                              --force)
  --help                      Show this message and exit.
```

```
Usage: pbt tag [OPTIONS]

Options:
  --path TEXT       Path to the directory containing the pbt_project.yml file
                    [required]
  --repo-path TEXT  Path to the repository root. If left blank it will use '--
                    path'
  --no-push         By default the tag will be pushed to the origin after it
                    is created. Use this flag to skip pushing the tag.
  --branch TEXT     normally the tag is prefixed with the branch name:
                    <branch_name>/<version>. This overrides <branch_name>.
                    Provide "" to omit the branch name.
  --custom TEXT     Explicitly set the exact tag using a string. Ignores other
                    options.
  --help            Show this message and exit.
  ```

