### PR TITLE
Rj/versioning check helpers

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -21,6 +21,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+      fetch-depth: 0
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v3
       with:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -21,7 +21,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-      fetch-depth: 0
+      with:
+        fetch-depth: 0
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v3
       with:

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -21,7 +21,8 @@ jobs:
       fail-fast: true
     steps:
     - uses: actions/checkout@v3
-      fetch-depth: 0
+      with:
+        fetch-depth: 0
     - name: Set up Python
       uses: actions/setup-python@v3
       with:

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -21,6 +21,7 @@ jobs:
       fail-fast: true
     steps:
     - uses: actions/checkout@v3
+      fetch-depth: 0
     - name: Set up Python
       uses: actions/setup-python@v3
       with:

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,3 +23,4 @@ botocore~=1.34.154
 packaging~=24.1
 pyspark~=3.3.0
 parameterized~=0.9.0
+semver~=3.0.2

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as _in:
 
 setuptools.setup(
     name="prophecy-build-tool",
-    version="1.2.40",
+    version="1.2.42",
     author="Prophecy",
     author_email="maciej@prophecy.io",
     description="Prophecy-build-tool (PBT) provides utilities to build and distribute projects created from the "

--- a/src/pbt/__init__.py
+++ b/src/pbt/__init__.py
@@ -342,7 +342,7 @@ def test(path, driver_library_path, pipelines):
     "--set-suffix",
     type=str,
     help="Set a suffix string. example '-SNAPSHOT' or '-rc.4' . If this is not a valid semVer string an error will be "
-         "thrown.",
+    "thrown.",
     required=False,
 )
 @click.option(
@@ -357,21 +357,21 @@ def test(path, driver_library_path, pipelines):
     "--compare",
     type=str,
     help="Checks to see if current branch has a greater version number than the <TARGET> branch name provided. Returns "
-         "0 true, or 1 false. (Also performs --sync check). NOTE: if you provide '--bump'  with this option then it will"
-         "compare the current version with the version in the target branch and use the bump strategy IF the current "
-         "version is lower than the target. ",
+    "0 true, or 1 false. (Also performs --sync check). NOTE: if you provide '--bump'  with this option then it will"
+    "compare the current version with the version in the target branch and use the bump strategy IF the current "
+    "version is lower than the target. ",
     required=False,
     default="main",
 )
 @click.option(
     "--make-unique",
     help="Helper function that makes a version unique for feature branches. Adds build-metadata suffix to differentiate"
-         " this feature branch from other dev branches (hash based on branch name). Adds Prerelease candidate to "
-         " deprioritize this version from being chosen over other versions (recommended so that it does not "
-         " accidentally get chosen over a real release. "
-         "format: MAJOR.MINOR.PATCH-PRERELEASE+BUILDMETADATA"
-         "python example: 3.3.0 -> 3.3.0-dev+sha.j0239ruf0ew"
-         "scala example: 3.3.0 -> 3.3.0-SNAPSHOT+sha.j0239ruf0ew",
+    " this feature branch from other dev branches (hash based on branch name). Adds Prerelease candidate to "
+    " deprioritize this version from being chosen over other versions (recommended so that it does not "
+    " accidentally get chosen over a real release. "
+    "format: MAJOR.MINOR.PATCH-PRERELEASE+BUILDMETADATA"
+    "python example: 3.3.0 -> 3.3.0-dev+sha.j0239ruf0ew"
+    "scala example: 3.3.0 -> 3.3.0-SNAPSHOT+sha.j0239ruf0ew",
     default=False,
     is_flag=True,
     required=False,
@@ -388,7 +388,7 @@ def versioning(path, repo_path, bump, set, force, sync, set_suffix, check_sync, 
             check_sync,
             set_suffix is not None,
             compare_to_target is not None,
-            make_unique
+            make_unique,
         ]
     )
 

--- a/src/pbt/__init__.py
+++ b/src/pbt/__init__.py
@@ -305,6 +305,11 @@ def test(path, driver_library_path, pipelines):
     required=True,
 )
 @click.option(
+    "--repo-path",
+    help="Path to the repository root. If left blank it will use '--path'",
+    required=False,
+)
+@click.option(
     "--bump",
     type=click.Choice(["major", "minor", "patch", "build", "prerelease"], case_sensitive=False),
     help="bumps one of the semantic version numbers for the project and all pipelines based on the current value. "
@@ -348,12 +353,14 @@ def test(path, driver_library_path, pipelines):
 @click.option(
     "--check-if-bumped",
     type=str,
-    help="Checks to see if current branch has a greater version number than the branch name you provide",
+    help="Checks to see if current branch has a greater version number than the branch name you provide. "
+         "(takes --repo-path if necessary)",
     required=False,
 )
-def versioning(path, bump, set, force, sync, set_prerelease, check_sync, check_if_bumped):
+def versioning(path, repo_path, bump, set, force, sync, set_prerelease, check_sync, check_if_bumped):
     pbt = PBTCli.from_conf_folder(path)
-
+    if not repo_path:
+        repo_path = path
     if sum([set is not None,
             bump is not None,
             sync,
@@ -372,7 +379,7 @@ def versioning(path, bump, set, force, sync, set_prerelease, check_sync, check_i
     elif check_sync:
         pbt.version_check_sync()
     elif check_if_bumped:
-        pbt.version_check_if_bumped(check_if_bumped)
+        pbt.version_check_if_bumped(repo_path, check_if_bumped)
     else:
         raise click.UsageError("must give ONE of: '--set', '--bump', '--sync', --set-prerelease'")
 

--- a/src/pbt/__init__.py
+++ b/src/pbt/__init__.py
@@ -354,20 +354,29 @@ def test(path, driver_library_path, pipelines):
     "--check-if-bumped",
     type=str,
     help="Checks to see if current branch has a greater version number than the branch name you provide. "
-         "(takes --repo-path if necessary)",
+    "(takes --repo-path if necessary)",
     required=False,
 )
 def versioning(path, repo_path, bump, set, force, sync, set_prerelease, check_sync, check_if_bumped):
     pbt = PBTCli.from_conf_folder(path)
     if not repo_path:
         repo_path = path
-    if sum([set is not None,
-            bump is not None,
-            sync,
-            check_sync,
-            check_if_bumped is not None,
-            set_prerelease is not None]) > 1:
-        raise click.UsageError("Options '--set', '--bump', '--sync', '--check-sync', '--set-prerelease', '--check-if-bumped' are mutually exclusive.")
+    if (
+        sum(
+            [
+                set is not None,
+                bump is not None,
+                sync,
+                check_sync,
+                check_if_bumped is not None,
+                set_prerelease is not None,
+            ]
+        )
+        > 1
+    ):
+        raise click.UsageError(
+            "Options '--set', '--bump', '--sync', '--check-sync', '--set-prerelease', '--check-if-bumped' are mutually exclusive."
+        )
     elif set:
         pbt.version_set(set, force)
     elif bump:

--- a/src/pbt/__init__.py
+++ b/src/pbt/__init__.py
@@ -338,11 +338,29 @@ def test(path, driver_library_path, pipelines):
     help="Set a prerelease string. example '-SNAPSHOT' or '-rc.4'",
     required=False,
 )
-def versioning(path, bump, set, force, sync, set_prerelease):
+@click.option(
+    "--check-sync",
+    help="check to see if versions are synced. exit code 0 success, 1 failure.",
+    default=False,
+    is_flag=True,
+    required=False,
+)
+@click.option(
+    "--check-if-bumped",
+    type=str,
+    help="Checks to see if current branch has a greater version number than the branch name you provide",
+    required=False,
+)
+def versioning(path, bump, set, force, sync, set_prerelease, check_sync, check_if_bumped):
     pbt = PBTCli.from_conf_folder(path)
 
-    if sum([set is not None, bump is not None, sync, set_prerelease is not None]) > 1:
-        raise click.UsageError("Options '--set', '--bump', '--sync' are mutually exclusive.")
+    if sum([set is not None,
+            bump is not None,
+            sync,
+            check_sync,
+            check_if_bumped is not None,
+            set_prerelease is not None]) > 1:
+        raise click.UsageError("Options '--set', '--bump', '--sync', '--check-sync', '--set-prerelease', '--check-if-bumped' are mutually exclusive.")
     elif set:
         pbt.version_set(set, force)
     elif bump:
@@ -351,6 +369,10 @@ def versioning(path, bump, set, force, sync, set_prerelease):
         pbt.version_set(None, force)
     elif set_prerelease:
         pbt.version_set_prerelease(set_prerelease, force)
+    elif check_sync:
+        pbt.version_check_sync()
+    elif check_if_bumped:
+        pbt.version_check_if_bumped(check_if_bumped)
     else:
         raise click.UsageError("must give ONE of: '--set', '--bump', '--sync', --set-prerelease'")
 

--- a/src/pbt/__init__.py
+++ b/src/pbt/__init__.py
@@ -302,16 +302,13 @@ def test(path, driver_library_path, pipelines):
 
 @cli.command()
 @click.option(
-    "--path",
-    help="Path to the directory containing the pbt_project.yml file",
-    required=True,
-    metavar="<PATH>"
+    "--path", help="Path to the directory containing the pbt_project.yml file", required=True, metavar="<PATH>"
 )
 @click.option(
     "--repo-path",
     help="Path to the repository root. If left blank it will use '--path'",
     required=False,
-    metavar="<PATH>"
+    metavar="<PATH>",
 )
 @click.option(
     "--bump",
@@ -422,7 +419,9 @@ def versioning(path, repo_path, bump, set, force, sync, set_suffix, check_sync, 
                 # when bump is given then use the strategy to bump over the version found in the target.
                 target_version = pbt.version_get_target_branch_version(repo_path, compare_to_target)
                 new_version = get_bumped_version(
-                    target_version, bump, pbt.project.project.pbt_project_dict["language"],
+                    target_version,
+                    bump,
+                    pbt.project.project.pbt_project_dict["language"],
                 )
                 pbt.version_set(new_version, force=True)
             else:

--- a/src/pbt/__init__.py
+++ b/src/pbt/__init__.py
@@ -356,28 +356,28 @@ def test(path, driver_library_path, pipelines):
     "--compare",
     type=str,
     help="Checks to see if current branch has a greater version number than the <TARGET> branch name provided. Returns "
-        "0 true, or 1 false. (Also performs --sync check). NOTE: if you provide '--bump'  with this option then it will"
-        "compare the current version with the version in the target branch and use the bump strategy IF the current "
-        "version is lower than the target. ",
+    "0 true, or 1 false. (Also performs --sync check). NOTE: if you provide '--bump'  with this option then it will"
+    "compare the current version with the version in the target branch and use the bump strategy IF the current "
+    "version is lower than the target. ",
     required=False,
-    default="main"
+    default="main",
 )
 def versioning(path, repo_path, bump, set, force, sync, set_prerelease, check_sync, compare_to_target):
     pbt = PBTCli.from_conf_folder(path)
     if not repo_path:
         repo_path = path
     option_total = sum(
-            [
-                set is not None,
-                bump is not None,
-                sync,
-                check_sync,
-                set_prerelease is not None,
-                compare_to_target is not None,
-                ]
-        )
+        [
+            set is not None,
+            bump is not None,
+            sync,
+            check_sync,
+            set_prerelease is not None,
+            compare_to_target is not None,
+        ]
+    )
 
-    if (option_total > 1):
+    if option_total > 1:
         if option_total == 2 and compare_to_target and bump:
             pass  # this is the one combo that is allowed; compare_to_target and bump
         else:
@@ -412,8 +412,10 @@ def versioning(path, repo_path, bump, set, force, sync, set_prerelease, check_sy
             else:
                 pbt.version_check_sync()
     else:
-        raise click.UsageError("must give ONE of: '--set', '--bump', '--sync', '--check-sync', '--set-prerelease', "
-                               " '--compare-to-target'")
+        raise click.UsageError(
+            "must give ONE of: '--set', '--bump', '--sync', '--check-sync', '--set-prerelease', "
+            " '--compare-to-target'"
+        )
 
 
 @cli.command()

--- a/src/pbt/entities/project.py
+++ b/src/pbt/entities/project.py
@@ -396,9 +396,13 @@ class Project:
         return False
 
     def update_version(self, new_version, force=False):
-        update_all_versions(self.project_path, self.project_language,
-                            orig_project_version=self.pbt_project_dict["version"],
-                            new_version=new_version, force=force)
+        update_all_versions(
+            self.project_path,
+            self.project_language,
+            orig_project_version=self.pbt_project_dict["version"],
+            new_version=new_version,
+            force=force,
+        )
         # update our internal reference in case calls get chained which use this field.
         self.pbt_project_dict["version"] = new_version
 

--- a/src/pbt/entities/project.py
+++ b/src/pbt/entities/project.py
@@ -24,6 +24,7 @@ from ..utils.constants import (
     PROJECT_URL_PLACEHOLDER_REGEX,
 )
 from ..utils.exceptions import ProjectPathNotFoundException, ProjectFileNotFoundException
+from ..utils.versioning import update_all_versions
 
 SUBSCRIBED_ENTITY_URI_REGEX = re.compile(
     r"gitUri=(.*)&subPath=(.*)&tag=(.*)&projectSubscriptionProjectId=(.*)&path=(.*)"
@@ -393,6 +394,13 @@ class Project:
                         return is_dynamic
 
         return False
+
+    def update_version(self, new_version, force=False):
+        update_all_versions(self.project_path, self.project_language,
+                            orig_project_version=self.pbt_project_dict["version"],
+                            new_version=new_version, force=force)
+        # update our internal reference in case calls get chained which use this field.
+        self.pbt_project_dict["version"] = new_version
 
 
 class DependentProject(ABC):

--- a/src/pbt/pbt_cli.py
+++ b/src/pbt/pbt_cli.py
@@ -5,7 +5,7 @@ from .entities.project import Project
 from .utils.project_config import ProjectConfig
 from .utility import custom_print as log
 import git
-from .utils.versioning import update_all_versions, get_bumped_version
+from .utils.versioning import update_all_versions, get_bumped_version, version_check_sync
 
 
 class PBTCli(object):
@@ -110,6 +110,11 @@ class PBTCli(object):
 
     def version_set_prerelease(self, prerelease_string, force):
         self.version_set(self.project.project.pbt_project_dict["version"] + prerelease_string, force)
+
+    def version_check_sync(self):
+        version_check_sync(self.project.project.project_path,
+                           self.project.project.pbt_project_dict['language'],
+                           self.project.project.pbt_project_dict['version'])
 
     def tag(self, repo_path, no_push=False, branch=None, custom=None):
         repo = git.Repo(repo_path)

--- a/src/pbt/pbt_cli.py
+++ b/src/pbt/pbt_cli.py
@@ -12,6 +12,7 @@ from .utils.versioning import update_all_versions, get_bumped_version, version_c
 import semver
 from .utils.constants import SCALA_LANGUAGE
 import hashlib
+import sys
 
 
 class PBTCli(object):
@@ -115,7 +116,15 @@ class PBTCli(object):
         )
 
     def version_set_suffix(self, suffix, force):
-        self.version_set(self.project.project.pbt_project_dict["version"] + suffix, force)
+        if not semver.Version.is_valid(self.project.project.pbt_project_dict["version"]):
+            print("ERROR: current version is not in semVer syntax. cannot proceed.")
+            sys.exit(1)
+        current_version = semver.parse_version_info(self.project.project.pbt_project_dict["version"])
+        new_version_str = f"{current_version.major}.{current_version.minor}.{current_version.patch}{suffix}"
+        if not semver.Version.is_valid(new_version_str) and not force:
+            print("ERROR: suffix provided is not valid semVer syntax. You can use --force to ignore this.")
+            sys.exit(1)
+        self.version_set(new_version_str, force)
 
     def version_check_sync(self):
         version_check_sync(

--- a/src/pbt/pbt_cli.py
+++ b/src/pbt/pbt_cli.py
@@ -116,18 +116,21 @@ class PBTCli(object):
         self.version_set(self.project.project.pbt_project_dict["version"] + prerelease_string, force)
 
     def version_check_sync(self):
-        version_check_sync(self.project.project.project_path,
-                           self.project.project.pbt_project_dict['language'],
-                           self.project.project.pbt_project_dict['version'])
+        version_check_sync(
+            self.project.project.project_path,
+            self.project.project.pbt_project_dict["language"],
+            self.project.project.pbt_project_dict["version"],
+        )
 
     def version_check_if_bumped(self, repo_path, branch):
-        current_pbt_version = self.project.project.pbt_project_dict['version']
+        current_pbt_version = self.project.project.pbt_project_dict["version"]
         repo = git.Repo(repo_path)
-        subpath = os.path.relpath(os.path.join(self.project.project.project_path, "pbt_project.yml"),
-                                  os.path.abspath(repo_path))
-        branch_content = repo.git.show(f'{branch}:{subpath}')
+        subpath = os.path.relpath(
+            os.path.join(self.project.project.project_path, "pbt_project.yml"), os.path.abspath(repo_path)
+        )
+        branch_content = repo.git.show(f"{branch}:{subpath}")
         branch_pbt_dict = yaml.safe_load(branch_content)
-        branch_pbt_version = branch_pbt_dict['version']
+        branch_pbt_version = branch_pbt_dict["version"]
         try:
             if semver.parse_version_info(current_pbt_version) <= semver.parse_version_info(branch_pbt_version):
                 log(f"Current version is not higher than base version: {current_pbt_version} <= {branch_pbt_version}")

--- a/src/pbt/pbt_cli.py
+++ b/src/pbt/pbt_cli.py
@@ -10,6 +10,8 @@ from .utility import custom_print as log
 import git
 from .utils.versioning import update_all_versions, get_bumped_version, version_check_sync
 import semver
+from .utils.constants import SCALA_LANGUAGE
+import hashlib
 
 
 class PBTCli(object):
@@ -112,8 +114,8 @@ class PBTCli(object):
             force=force,
         )
 
-    def version_set_prerelease(self, prerelease_string, force):
-        self.version_set(self.project.project.pbt_project_dict["version"] + prerelease_string, force)
+    def version_set_suffix(self, suffix, force):
+        self.version_set(self.project.project.pbt_project_dict["version"] + suffix, force)
 
     def version_check_sync(self):
         version_check_sync(
@@ -121,6 +123,15 @@ class PBTCli(object):
             self.project.project.pbt_project_dict["language"],
             self.project.project.pbt_project_dict["version"],
         )
+
+    def version_make_unique(self, repo_path, force):
+        repo = git.Repo(repo_path)
+        branch_name = repo.active_branch.name
+        branch_hash = hashlib.sha256(branch_name.encode()).hexdigest()[:8]
+        if self.project.project.project_language == SCALA_LANGUAGE:
+            self.version_set_suffix(f"-SNAPSHOT+sha.{branch_hash}", force)
+        else:
+            self.version_set_suffix(f"-dev+sha.{branch_hash}", force)
 
     def version_get_target_branch_version(self, repo_path, target_branch):
         repo = git.Repo(repo_path)

--- a/src/pbt/utils/versioning.py
+++ b/src/pbt/utils/versioning.py
@@ -9,34 +9,34 @@ import xml.etree.ElementTree as ET
 
 
 def version_check_sync(project_path, project_language, pbt_project_version):
-    if project_language == 'python':
+    if project_language == "python":
         filename_to_find = "setup.py"
-    elif project_language == 'scala':
+    elif project_language == "scala":
         filename_to_find = "pom.xml"
-    elif project_language == 'sql':
+    elif project_language == "sql":
         filename_to_find = "dbt_project.yml"
     else:
         raise ValueError("bad project language: ", project_language)
 
-    files_to_check = glob.glob(os.path.join(project_path, '**', filename_to_find), recursive=True)
+    files_to_check = glob.glob(os.path.join(project_path, "**", filename_to_find), recursive=True)
 
     for f in files_to_check:
-        with open(f, 'r') as fd:
+        with open(f, "r") as fd:
             # replace version in language specific files:
-            if project_language == 'python':
+            if project_language == "python":
                 version_match_re = re.search(r"version\s*=\s*['\"]([^'\"]+)['\"]", fd.read())
                 if version_match_re:
                     file_version = version_match_re.group(1)
                 else:
                     raise ValueError(f"could not find version in file: {f}")
-            elif project_language == 'scala':
+            elif project_language == "scala":
                 tree = ET.parse(fd)
                 root = tree.getroot()
-                namespace = {'ns': 'http://maven.apache.org/POM/4.0.0'}
-                file_version = root.find('ns:version', namespace).text
-            elif project_language == 'sql':
+                namespace = {"ns": "http://maven.apache.org/POM/4.0.0"}
+                file_version = root.find("ns:version", namespace).text
+            elif project_language == "sql":
                 content_dict = yaml.safe_load(fd)
-                file_version = content_dict['version']
+                file_version = content_dict["version"]
             else:
                 raise ValueError("bad project language: ", project_language)
 

--- a/src/pbt/utils/versioning.py
+++ b/src/pbt/utils/versioning.py
@@ -24,9 +24,9 @@ def version_check_sync(project_path, project_language, pbt_project_version):
         with open(f, 'r') as fd:
             # replace version in language specific files:
             if project_language == 'python':
-                version_match = re.search(r"version\s*=\s*['\"]([^'\"]+)['\"]", fd.read())
-                if version_match:
-                    file_version = version_match.group(1)
+                version_match_re = re.search(r"version\s*=\s*['\"]([^'\"]+)['\"]", fd.read())
+                if version_match_re:
+                    file_version = version_match_re.group(1)
                 else:
                     raise ValueError(f"could not find version in file: {f}")
             elif project_language == 'scala':
@@ -41,7 +41,7 @@ def version_check_sync(project_path, project_language, pbt_project_version):
                 raise ValueError("bad project language: ", project_language)
 
             try:
-                if semver.parse_version_info(file_version) != semver.parse_version_info(pbt_project_version):
+                if semver.parse_version_info(pbt_project_version) != semver.parse_version_info(file_version):
                     log(f"Versions are out of sync: {pbt_project_version} != {file_version}")
                     exit(1)
             except ValueError as e:

--- a/src/pbt/utils/versioning.py
+++ b/src/pbt/utils/versioning.py
@@ -45,8 +45,10 @@ def version_check_sync(project_path, project_language, pbt_project_version):
                     log(f"Versions are out of sync: {pbt_project_version} != {file_version}")
                     exit(1)
             except ValueError as e:
-                log("Error: check-sync failed to parse one or more versions. "
-                    "versions are not synchronized in your code. Please run `pbt versioning --sync` to fix")
+                log(
+                    "Error: check-sync failed to parse one or more versions. "
+                    "versions are not synchronized in your code. Please run `pbt versioning --sync` to fix"
+                )
                 log(e)
                 exit(1)
 

--- a/src/pbt/utils/versioning.py
+++ b/src/pbt/utils/versioning.py
@@ -45,7 +45,8 @@ def version_check_sync(project_path, project_language, pbt_project_version):
                     log(f"Versions are out of sync: {pbt_project_version} != {file_version}")
                     exit(1)
             except ValueError as e:
-                log("failed to parse one or more versions. marking invalid.")
+                log("Error: check-sync failed to parse one or more versions. "
+                    "versions are not synchronized in your code. Please run `pbt versioning --sync` to fix")
                 log(e)
                 exit(1)
 

--- a/test/resources/HelloWorld/jobs/job-another/code/databricks-job.json
+++ b/test/resources/HelloWorld/jobs/job-another/code/databricks-job.json
@@ -4,7 +4,7 @@
     "PipelineComponent" : {
       "id" : "pipelines/farmers-markets-irs",
       "nodeName" : "farmers-markets-irs",
-      "path" : "dbfs:/FileStore/prophecy/artifacts/saas/app/__PROJECT_ID_PLACEHOLDER__/__PROJECT_RELEASE_VERSION_PLACEHOLDER__/pipeline/farmers_markets_irs-1.0-py3-none-any.whl",
+      "path" : "dbfs:/FileStore/prophecy/artifacts/saas/app/__PROJECT_ID_PLACEHOLDER__/__PROJECT_RELEASE_VERSION_PLACEHOLDER__/pipeline/farmers_markets_irs-0.0.1-py3-none-any.whl",
       "language" : "python"
     }
   } ],
@@ -28,7 +28,7 @@
           "prophecy.metadata.is.interactive.run" : "false",
           "prophecy.project.id" : "__PROJECT_ID_PLACEHOLDER__",
           "prophecy.execution.service.url" : "wss://execution.dp.app.prophecy.io/eventws",
-          "prophecy.packages.path" : "{\"pipelines/farmers-markets-irs\":\"dbfs:/FileStore/prophecy/artifacts/saas/app/__PROJECT_ID_PLACEHOLDER__/__PROJECT_RELEASE_VERSION_PLACEHOLDER__/pipeline/farmers_markets_irs-1.0-py3-none-any.whl\"}",
+          "prophecy.packages.path" : "{\"pipelines/farmers-markets-irs\":\"dbfs:/FileStore/prophecy/artifacts/saas/app/__PROJECT_ID_PLACEHOLDER__/__PROJECT_RELEASE_VERSION_PLACEHOLDER__/pipeline/farmers_markets_irs-0.0.1-py3-none-any.whl\"}",
           "prophecy.metadata.job.branch" : "__PROJECT_RELEASE_VERSION_PLACEHOLDER__",
           "prophecy.metadata.url" : "__PROPHECY_URL_PLACEHOLDER__",
           "prophecy.execution.metrics.disabled" : false
@@ -53,7 +53,7 @@
           "package" : "prophecy-libs==1.5.0"
         }
       }, {
-        "whl" : "dbfs:/FileStore/prophecy/artifacts/saas/app/__PROJECT_ID_PLACEHOLDER__/__PROJECT_RELEASE_VERSION_PLACEHOLDER__/pipeline/farmers_markets_irs-1.0-py3-none-any.whl"
+        "whl" : "dbfs:/FileStore/prophecy/artifacts/saas/app/__PROJECT_ID_PLACEHOLDER__/__PROJECT_RELEASE_VERSION_PLACEHOLDER__/pipeline/farmers_markets_irs-0.0.1-py3-none-any.whl"
       } ],
       "email_notifications" : { },
       "max_retries" : 0

--- a/test/resources/HelloWorld/jobs/test-job/code/databricks-job.json
+++ b/test/resources/HelloWorld/jobs/test-job/code/databricks-job.json
@@ -4,21 +4,21 @@
     "PipelineComponent" : {
       "id" : "pipelines/customers_orders",
       "nodeName" : "customers_orders",
-      "path" : "dbfs:/FileStore/prophecy/artifacts/saas/app/__PROJECT_ID_PLACEHOLDER__/__PROJECT_RELEASE_VERSION_PLACEHOLDER__/pipeline/customers_orders1243-1.0-py3-none-any.whl",
+      "path" : "dbfs:/FileStore/prophecy/artifacts/saas/app/__PROJECT_ID_PLACEHOLDER__/__PROJECT_RELEASE_VERSION_PLACEHOLDER__/pipeline/customers_orders1243-0.0.1-py3-none-any.whl",
       "language" : "python"
     }
   }, {
     "PipelineComponent" : {
       "id" : "pipelines/join_agg_sort",
       "nodeName" : "join_agg_sort",
-      "path" : "dbfs:/FileStore/prophecy/artifacts/saas/app/__PROJECT_ID_PLACEHOLDER__/__PROJECT_RELEASE_VERSION_PLACEHOLDER__/pipeline/join_agg_sort-1.0-py3-none-any.whl",
+      "path" : "dbfs:/FileStore/prophecy/artifacts/saas/app/__PROJECT_ID_PLACEHOLDER__/__PROJECT_RELEASE_VERSION_PLACEHOLDER__/pipeline/join_agg_sort-0.0.1-py3-none-any.whl",
       "language" : "python"
     }
   }, {
     "PipelineComponent" : {
       "id" : "pipelines/report_top_customers",
       "nodeName" : "report_top_customers",
-      "path" : "dbfs:/FileStore/prophecy/artifacts/saas/app/__PROJECT_ID_PLACEHOLDER__/__PROJECT_RELEASE_VERSION_PLACEHOLDER__/pipeline/report_top_customers-1.0-py3-none-any.whl",
+      "path" : "dbfs:/FileStore/prophecy/artifacts/saas/app/__PROJECT_ID_PLACEHOLDER__/__PROJECT_RELEASE_VERSION_PLACEHOLDER__/pipeline/report_top_customers-0.0.1-py3-none-any.whl",
       "language" : "python"
     }
   } ],
@@ -42,7 +42,7 @@
           "prophecy.metadata.is.interactive.run" : "false",
           "prophecy.project.id" : "__PROJECT_ID_PLACEHOLDER__",
           "prophecy.execution.service.url" : "wss://execution.dp.app.prophecy.io/eventws",
-          "prophecy.packages.path" : "{\"pipelines/customers_orders\":\"dbfs:/FileStore/prophecy/artifacts/saas/app/__PROJECT_ID_PLACEHOLDER__/__PROJECT_RELEASE_VERSION_PLACEHOLDER__/pipeline/customers_orders1243-1.0-py3-none-any.whl\",\"pipelines/join_agg_sort\":\"dbfs:/FileStore/prophecy/artifacts/saas/app/__PROJECT_ID_PLACEHOLDER__/__PROJECT_RELEASE_VERSION_PLACEHOLDER__/pipeline/join_agg_sort-1.0-py3-none-any.whl\",\"pipelines/report_top_customers\":\"dbfs:/FileStore/prophecy/artifacts/saas/app/__PROJECT_ID_PLACEHOLDER__/__PROJECT_RELEASE_VERSION_PLACEHOLDER__/pipeline/report_top_customers-1.0-py3-none-any.whl\"}",
+          "prophecy.packages.path" : "{\"pipelines/customers_orders\":\"dbfs:/FileStore/prophecy/artifacts/saas/app/__PROJECT_ID_PLACEHOLDER__/__PROJECT_RELEASE_VERSION_PLACEHOLDER__/pipeline/customers_orders1243-0.0.1-py3-none-any.whl\",\"pipelines/join_agg_sort\":\"dbfs:/FileStore/prophecy/artifacts/saas/app/__PROJECT_ID_PLACEHOLDER__/__PROJECT_RELEASE_VERSION_PLACEHOLDER__/pipeline/join_agg_sort-0.0.1-py3-none-any.whl\",\"pipelines/report_top_customers\":\"dbfs:/FileStore/prophecy/artifacts/saas/app/__PROJECT_ID_PLACEHOLDER__/__PROJECT_RELEASE_VERSION_PLACEHOLDER__/pipeline/report_top_customers-0.0.1-py3-none-any.whl\"}",
           "prophecy.metadata.job.branch" : "__PROJECT_RELEASE_VERSION_PLACEHOLDER__",
           "prophecy.metadata.url" : "__PROPHECY_URL_PLACEHOLDER__",
           "prophecy.execution.metrics.disabled" : false
@@ -67,7 +67,7 @@
           "package" : "prophecy-libs==1.5.0"
         }
       }, {
-        "whl" : "dbfs:/FileStore/prophecy/artifacts/saas/app/__PROJECT_ID_PLACEHOLDER__/__PROJECT_RELEASE_VERSION_PLACEHOLDER__/pipeline/customers_orders1243-1.0-py3-none-any.whl"
+        "whl" : "dbfs:/FileStore/prophecy/artifacts/saas/app/__PROJECT_ID_PLACEHOLDER__/__PROJECT_RELEASE_VERSION_PLACEHOLDER__/pipeline/customers_orders1243-0.0.1-py3-none-any.whl"
       } ],
       "email_notifications" : { },
       "max_retries" : 0
@@ -91,7 +91,7 @@
           "package" : "prophecy-libs==1.5.0"
         }
       }, {
-        "whl" : "dbfs:/FileStore/prophecy/artifacts/saas/app/__PROJECT_ID_PLACEHOLDER__/__PROJECT_RELEASE_VERSION_PLACEHOLDER__/pipeline/join_agg_sort-1.0-py3-none-any.whl"
+        "whl" : "dbfs:/FileStore/prophecy/artifacts/saas/app/__PROJECT_ID_PLACEHOLDER__/__PROJECT_RELEASE_VERSION_PLACEHOLDER__/pipeline/join_agg_sort-0.0.1-py3-none-any.whl"
       } ],
       "email_notifications" : { },
       "max_retries" : 0
@@ -115,7 +115,7 @@
           "package" : "prophecy-libs==1.5.0"
         }
       }, {
-        "whl" : "dbfs:/FileStore/prophecy/artifacts/saas/app/__PROJECT_ID_PLACEHOLDER__/__PROJECT_RELEASE_VERSION_PLACEHOLDER__/pipeline/report_top_customers-1.0-py3-none-any.whl"
+        "whl" : "dbfs:/FileStore/prophecy/artifacts/saas/app/__PROJECT_ID_PLACEHOLDER__/__PROJECT_RELEASE_VERSION_PLACEHOLDER__/pipeline/report_top_customers-0.0.1-py3-none-any.whl"
       } ],
       "email_notifications" : { },
       "max_retries" : 0

--- a/test/resources/HelloWorld/pipelines/customers_orders/code/setup.py
+++ b/test/resources/HelloWorld/pipelines/customers_orders/code/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 setup(
     name = 'customers_orders1243',
-    version = '1.0',
+    version = '0.0.1',
     packages = find_packages(include = ('job*', )) + ["prophecy_config_instances"],
     package_dir = {'prophecy_config_instances' : 'configs/resources/config'},
     package_data = {'prophecy_config_instances' : ['*.json', '*.py']},

--- a/test/resources/HelloWorld/pipelines/farmers-markets-irs/code/setup.py
+++ b/test/resources/HelloWorld/pipelines/farmers-markets-irs/code/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 setup(
     name = 'farmers-markets-irs',
-    version = '1.0',
+    version = '0.0.1',
     packages = find_packages(include = ('job*', )) + ["prophecy_config_instances"],
     package_dir = {'prophecy_config_instances' : 'configs/resources/config'},
     package_data = {'prophecy_config_instances' : ['*.json', '*.py']},

--- a/test/resources/HelloWorld/pipelines/join_agg_sort/code/setup.py
+++ b/test/resources/HelloWorld/pipelines/join_agg_sort/code/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 setup(
     name = 'join_agg_sort',
-    version = '1.0',
+    version = '0.0.1',
     packages = find_packages(include = ('job*', )) + ["prophecy_config_instances"],
     package_dir = {'prophecy_config_instances' : 'configs/resources/config'},
     package_data = {'prophecy_config_instances' : ['*.json', '*.py']},

--- a/test/resources/HelloWorld/pipelines/report_top_customers/code/setup.py
+++ b/test/resources/HelloWorld/pipelines/report_top_customers/code/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 setup(
     name = 'report_top_customers',
-    version = '1.0',
+    version = '0.0.1',
     packages = find_packages(include = ('job*', )) + ["prophecy_config_instances"],
     package_dir = {'prophecy_config_instances' : 'configs/resources/config'},
     package_data = {'prophecy_config_instances' : ['*.json', '*.py']},

--- a/test/test_versioning.py
+++ b/test/test_versioning.py
@@ -187,7 +187,33 @@ class VersioningTestCase(unittest.TestCase):
         with open(os.path.join(project_path, "pipelines/customers_orders/code/setup.py"), "w") as fd:
             fd.write(content)
 
-        runner = CliRunner()
         result = runner.invoke(versioning, ["--path", project_path, "--check-sync"])
         assert result.exit_code == 1
         assert "Versions are out of sync" in result.output
+
+    def test_versioning_compare_to_target(self):
+
+        project_path = os.path.join(RESOURCES_PATH, "HelloWorld")
+
+        runner = CliRunner()
+        result = runner.invoke(versioning, ["--path", project_path, "--repo-path", REPO_PATH,
+                                            "--compare", "pytest_big_version"])
+        assert result.exit_code == 1
+
+        result = runner.invoke(versioning, ["--path", project_path, "--repo-path", REPO_PATH,
+                                            "--compare", "pytest_small_version"])
+        assert result.exit_code == 0
+
+        result = runner.invoke(versioning, ["--path", project_path, "--repo-path", REPO_PATH,
+                                            "--compare", "pytest_bad_version"])
+        assert result.exit_code == 0
+
+        
+
+    def test_versioning_bump_target(self):
+        pass
+
+    def test_versioning_make_unique(self):
+        pass
+
+

--- a/test/test_versioning.py
+++ b/test/test_versioning.py
@@ -29,7 +29,6 @@ class VersioningTestCase(unittest.TestCase):
         cls.repo.git.checkout("pytest/test_bad_version")
         cls.repo.git.checkout(current_branch)
 
-
     @classmethod
     def tearDown(cls):
         # Reset all changes in the 'test/' directory

--- a/test/test_versioning.py
+++ b/test/test_versioning.py
@@ -191,4 +191,3 @@ class VersioningTestCase(unittest.TestCase):
         result = runner.invoke(versioning, ["--path", project_path, "--check-sync"])
         assert result.exit_code == 1
         assert "Versions are out of sync" in result.output
-

--- a/test/test_versioning.py
+++ b/test/test_versioning.py
@@ -19,6 +19,16 @@ class VersioningTestCase(unittest.TestCase):
     def setUpClass(cls):
         # Initialize the repo object and set it as a class attribute
         cls.repo = git.Repo(os.getcwd())
+        # pull the following branches for testing.
+        cls.repo.git.fetch("origin", "pytest/test_big_version")
+        cls.repo.git.fetch("origin", "pytest/test_small_version")
+        cls.repo.git.fetch("origin", "pytest/test_bad_version")
+        current_branch = cls.repo.active_branch.name
+        cls.repo.git.checkout("pytest/test_big_version")
+        cls.repo.git.checkout("pytest/test_small_version")
+        cls.repo.git.checkout("pytest/test_bad_version")
+        cls.repo.git.checkout(current_branch)
+
 
     @classmethod
     def tearDown(cls):
@@ -194,16 +204,6 @@ class VersioningTestCase(unittest.TestCase):
     def test_versioning_compare_to_target(self):
         project_path = os.path.join(RESOURCES_PATH, "HelloWorld")
 
-        # pull the following branches for testing.
-        self.repo.git.fetch("origin", "pytest/test_big_version")
-        self.repo.git.fetch("origin", "pytest/test_small_version")
-        self.repo.git.fetch("origin", "pytest/test_bad_version")
-        current_branch = self.repo.active_branch.name
-        self.repo.git.checkout("pytest/test_big_version")
-        self.repo.git.checkout("pytest/test_small_version")
-        self.repo.git.checkout("pytest/test_bad_version")
-        self.repo.git.checkout(current_branch)
-
         runner = CliRunner()
         result = runner.invoke(
             versioning, ["--path", project_path, "--repo-path", REPO_PATH, "--compare", "pytest/test_big_version"]
@@ -225,12 +225,6 @@ class VersioningTestCase(unittest.TestCase):
 
     def test_versioning_bump_target(self):
         project_path = os.path.join(RESOURCES_PATH, "HelloWorld")
-
-        # pull the following branches for testing.
-        self.repo.git.fetch("origin", "pytest/test_big_version")
-        current_branch = self.repo.active_branch.name
-        self.repo.git.checkout("pytest/test_big_version")
-        self.repo.git.checkout(current_branch)
 
         runner = CliRunner()
         result = runner.invoke(

--- a/test/test_versioning.py
+++ b/test/test_versioning.py
@@ -21,7 +21,9 @@ class VersioningTestCase(unittest.TestCase):
         cls.repo = git.Repo(os.getcwd())
         cls.orig_repo_head = cls.get_current_repo_head()
         # pull the following branches for testing.
-        cls.repo.git.stash("save")
+        repo_dirty = cls.repo.is_dirty()
+        if repo_dirty:
+             cls.repo.git.stash("save")
         cls.repo.git.fetch("origin", "pytest/test_big_version")
         cls.repo.git.fetch("origin", "pytest/test_small_version")
         cls.repo.git.fetch("origin", "pytest/test_bad_version")
@@ -29,7 +31,8 @@ class VersioningTestCase(unittest.TestCase):
         cls.repo.git.checkout("pytest/test_small_version")
         cls.repo.git.checkout("pytest/test_bad_version")
         cls.repo.git.checkout(cls.orig_repo_head)
-        cls.repo.git.stash("pop")
+        if repo_dirty:
+            cls.repo.git.stash("pop")
 
     @classmethod
     def tearDown(cls):
@@ -277,7 +280,9 @@ class VersioningTestCase(unittest.TestCase):
     def test_versioning_make_unique(self):
         project_path = os.path.join(RESOURCES_PATH, "HelloWorld")
 
-        self.repo.git.stash("save")
+        repo_dirty = self.repo.is_dirty()
+        if repo_dirty:
+            self.repo.git.stash("save")
         try:
             if "pytest/static_branch_name" not in self.repo.branches:
                 self.repo.git.checkout("-b", "pytest/static_branch_name")
@@ -293,4 +298,5 @@ class VersioningTestCase(unittest.TestCase):
         finally:
             self.reset_changed_files("test/resources/")
             self.repo.git.checkout(self.orig_repo_head)
-            self.repo.git.stash("pop")
+            if repo_dirty:
+                self.repo.git.stash("pop")

--- a/test/test_versioning.py
+++ b/test/test_versioning.py
@@ -194,6 +194,16 @@ class VersioningTestCase(unittest.TestCase):
     def test_versioning_compare_to_target(self):
         project_path = os.path.join(RESOURCES_PATH, "HelloWorld")
 
+        # pull the following branches for testing.
+        self.repo.git.fetch('origin', 'pytest/test_big_version')
+        self.repo.git.fetch('origin', 'pytest/test_small_version')
+        self.repo.git.fetch('origin', 'pytest/test_bad_version')
+        current_branch = self.repo.active_branch.name
+        self.repo.git.checkout("pytest/test_big_version")
+        self.repo.git.checkout("pytest/test_small_version")
+        self.repo.git.checkout("pytest/test_bad_version")
+        self.repo.git.checkout(current_branch)
+
         runner = CliRunner()
         result = runner.invoke(
             versioning, ["--path", project_path, "--repo-path", REPO_PATH, "--compare", "pytest/test_big_version"]
@@ -215,6 +225,12 @@ class VersioningTestCase(unittest.TestCase):
 
     def test_versioning_bump_target(self):
         project_path = os.path.join(RESOURCES_PATH, "HelloWorld")
+
+        # pull the following branches for testing.
+        self.repo.git.fetch('origin', 'pytest/test_big_version')
+        current_branch = self.repo.active_branch.name
+        self.repo.git.checkout("pytest/test_big_version")
+        self.repo.git.checkout(current_branch)
 
         runner = CliRunner()
         result = runner.invoke(

--- a/test/test_versioning.py
+++ b/test/test_versioning.py
@@ -277,14 +277,20 @@ class VersioningTestCase(unittest.TestCase):
     def test_versioning_make_unique(self):
         project_path = os.path.join(RESOURCES_PATH, "HelloWorld")
 
-        if "pytest/static_branch_name" not in self.repo.branches:
-            self.repo.git.checkout("-b", "pytest/static_branch_name")
-        else:
-            self.repo.git.checkout("pytest/static_branch_name")
+        self.repo.git.stash("save")
+        try:
+            if "pytest/static_branch_name" not in self.repo.branches:
+                self.repo.git.checkout("-b", "pytest/static_branch_name")
+            else:
+                self.repo.git.checkout("pytest/static_branch_name")
 
-        runner = CliRunner()
-        result = runner.invoke(versioning, ["--path", project_path, "--repo-path", REPO_PATH, "--make-unique"])
-        print(result.output)
-        assert result.exit_code == 0
-        pbt_version = VersioningTestCase._get_pbt_version(project_path)
-        assert pbt_version == "0.0.1-dev+sha.062f87eb"
+            runner = CliRunner()
+            result = runner.invoke(versioning, ["--path", project_path, "--repo-path", REPO_PATH, "--make-unique"])
+            print(result.output)
+            assert result.exit_code == 0
+            pbt_version = VersioningTestCase._get_pbt_version(project_path)
+            assert pbt_version == "0.0.1-dev+sha.062f87eb"
+        finally:
+            self.reset_changed_files("test/resources/")
+            self.repo.git.checkout(self.orig_repo_head)
+            self.repo.git.stash("pop")

--- a/test/test_versioning.py
+++ b/test/test_versioning.py
@@ -23,7 +23,7 @@ class VersioningTestCase(unittest.TestCase):
         cls.repo.git.fetch("origin", "pytest/test_big_version")
         cls.repo.git.fetch("origin", "pytest/test_small_version")
         cls.repo.git.fetch("origin", "pytest/test_bad_version")
-        current_branch = cls.repo.active_branch.name
+        current_branch = cls.repo.head.commit.hexsha
         cls.repo.git.checkout("pytest/test_big_version")
         cls.repo.git.checkout("pytest/test_small_version")
         cls.repo.git.checkout("pytest/test_bad_version")

--- a/test/test_versioning.py
+++ b/test/test_versioning.py
@@ -171,3 +171,19 @@ class VersioningTestCase(unittest.TestCase):
 
         new_pbt_version = VersioningTestCase._get_pbt_version(project_path)
         assert new_pbt_version == "999999.0.0"
+
+    def test_versioning_version_check_sync_python(self):
+        project_path = os.path.join(RESOURCES_PATH, "HelloWorld")
+
+        with open(os.path.join(project_path, "pipelines/customers_orders/code/setup.py"), 'r') as fd:
+            content = fd.read()
+
+        content = content.replace("version = '1.0'", "version = '999.0'")
+
+        with open(os.path.join(project_path, "pipelines/customers_orders/code/setup.py"), 'w') as fd:
+            fd.write(content)
+
+        runner = CliRunner()
+        result = runner.invoke(versioning, ["--path", project_path, '--check-sync'])
+        assert result.exit_code == 0
+

--- a/test/test_versioning.py
+++ b/test/test_versioning.py
@@ -23,7 +23,7 @@ class VersioningTestCase(unittest.TestCase):
         # pull the following branches for testing.
         repo_dirty = cls.repo.is_dirty()
         if repo_dirty:
-             cls.repo.git.stash("save")
+            cls.repo.git.stash("save")
         cls.repo.git.fetch("origin", "pytest/test_big_version")
         cls.repo.git.fetch("origin", "pytest/test_small_version")
         cls.repo.git.fetch("origin", "pytest/test_bad_version")

--- a/test/test_versioning.py
+++ b/test/test_versioning.py
@@ -138,7 +138,7 @@ class VersioningTestCase(unittest.TestCase):
         runner = CliRunner()
         result = runner.invoke(versioning, ["--path", project_path, "--bump", "major"])
         assert result.exit_code == 0
-        result = runner.invoke(versioning, ["--path", project_path, "--set-prerelease", "-SNAPSHOT", "--force"])
+        result = runner.invoke(versioning, ["--path", project_path, "--set-suffix", "-SNAPSHOT", "--force"])
         assert result.exit_code == 0
 
         new_pbt_version = VersioningTestCase._get_pbt_version(project_path)
@@ -147,7 +147,7 @@ class VersioningTestCase(unittest.TestCase):
     def test_versioning_set_prerelease_and_bump_python(self):
         project_path = os.path.join(RESOURCES_PATH, "HelloWorld")
         runner = CliRunner()
-        result = runner.invoke(versioning, ["--path", project_path, "--set-prerelease", "-rc.4", "--force"])
+        result = runner.invoke(versioning, ["--path", project_path, "--set-suffix", "-rc.4", "--force"])
         assert result.exit_code == 0
         result = runner.invoke(versioning, ["--path", project_path, "--bump", "prerelease"])
         assert result.exit_code == 0
@@ -192,7 +192,6 @@ class VersioningTestCase(unittest.TestCase):
         assert "Versions are out of sync" in result.output
 
     def test_versioning_compare_to_target(self):
-
         project_path = os.path.join(RESOURCES_PATH, "HelloWorld")
 
         runner = CliRunner()
@@ -209,14 +208,38 @@ class VersioningTestCase(unittest.TestCase):
         result = runner.invoke(versioning, ["--path", project_path, "--repo-path", REPO_PATH,
                                             "--compare", "pytest/test_bad_version"])
         print(result.output)
-        assert result.exit_code == 0
+        assert result.exit_code == 1
 
-        
 
     def test_versioning_bump_target(self):
-        pass
+        project_path = os.path.join(RESOURCES_PATH, "HelloWorld")
+
+        runner = CliRunner()
+        result = runner.invoke(versioning, ["--path", project_path, "--repo-path", REPO_PATH,
+                                            "--compare", "pytest/test_big_version",
+                                            "--bump", "patch"])
+        print(result.output)
+        assert result.exit_code == 0
+        pbt_version = VersioningTestCase._get_pbt_version(project_path)
+        assert pbt_version == "9999.0.1"
+
+        result = runner.invoke(versioning, ["--path", project_path, "--repo-path", REPO_PATH,
+                                            "--compare", "pytest/test_small_version",
+                                            "--bump", "patch"])
+        print(result.output)
+        assert result.exit_code == 0
+        assert pbt_version == "9999.0.1"
+
 
     def test_versioning_make_unique(self):
-        pass
+        project_path = os.path.join(RESOURCES_PATH, "HelloWorld")
+
+        runner = CliRunner()
+        result = runner.invoke(versioning, ["--path", project_path, "--repo-path", REPO_PATH,
+                                            "--make-unique"])
+        print(result.output)
+        assert result.exit_code == 0
+        pbt_version = VersioningTestCase._get_pbt_version(project_path)
+        assert pbt_version == "0.0.1-dev+sha.612978c2"
 
 

--- a/test/test_versioning.py
+++ b/test/test_versioning.py
@@ -175,14 +175,20 @@ class VersioningTestCase(unittest.TestCase):
     def test_versioning_version_check_sync_python(self):
         project_path = os.path.join(RESOURCES_PATH, "HelloWorld")
 
+        runner = CliRunner()
+        result = runner.invoke(versioning, ["--path", project_path, "--set", "1.2.3"])
+        assert result.exit_code == 0
+
         with open(os.path.join(project_path, "pipelines/customers_orders/code/setup.py"), "r") as fd:
             content = fd.read()
 
-        content = content.replace("version = '1.0'", "version = '999.0'")
+        content = content.replace("version = '1.2.3'", "version = '999.0.0'")
 
         with open(os.path.join(project_path, "pipelines/customers_orders/code/setup.py"), "w") as fd:
             fd.write(content)
 
         runner = CliRunner()
         result = runner.invoke(versioning, ["--path", project_path, "--check-sync"])
-        assert result.exit_code == 0
+        assert result.exit_code == 1
+        assert "Versions are out of sync" in result.output
+

--- a/test/test_versioning.py
+++ b/test/test_versioning.py
@@ -195,9 +195,9 @@ class VersioningTestCase(unittest.TestCase):
         project_path = os.path.join(RESOURCES_PATH, "HelloWorld")
 
         # pull the following branches for testing.
-        self.repo.git.fetch('origin', 'pytest/test_big_version')
-        self.repo.git.fetch('origin', 'pytest/test_small_version')
-        self.repo.git.fetch('origin', 'pytest/test_bad_version')
+        self.repo.git.fetch("origin", "pytest/test_big_version")
+        self.repo.git.fetch("origin", "pytest/test_small_version")
+        self.repo.git.fetch("origin", "pytest/test_bad_version")
         current_branch = self.repo.active_branch.name
         self.repo.git.checkout("pytest/test_big_version")
         self.repo.git.checkout("pytest/test_small_version")
@@ -227,7 +227,7 @@ class VersioningTestCase(unittest.TestCase):
         project_path = os.path.join(RESOURCES_PATH, "HelloWorld")
 
         # pull the following branches for testing.
-        self.repo.git.fetch('origin', 'pytest/test_big_version')
+        self.repo.git.fetch("origin", "pytest/test_big_version")
         current_branch = self.repo.active_branch.name
         self.repo.git.checkout("pytest/test_big_version")
         self.repo.git.checkout(current_branch)

--- a/test/test_versioning.py
+++ b/test/test_versioning.py
@@ -195,51 +195,69 @@ class VersioningTestCase(unittest.TestCase):
         project_path = os.path.join(RESOURCES_PATH, "HelloWorld")
 
         runner = CliRunner()
-        result = runner.invoke(versioning, ["--path", project_path, "--repo-path", REPO_PATH,
-                                            "--compare", "pytest/test_big_version"])
+        result = runner.invoke(
+            versioning, ["--path", project_path, "--repo-path", REPO_PATH, "--compare", "pytest/test_big_version"]
+        )
         print(result.output)
         assert result.exit_code == 1
 
-        result = runner.invoke(versioning, ["--path", project_path, "--repo-path", REPO_PATH,
-                                            "--compare", "pytest/test_small_version"])
+        result = runner.invoke(
+            versioning, ["--path", project_path, "--repo-path", REPO_PATH, "--compare", "pytest/test_small_version"]
+        )
         print(result.output)
         assert result.exit_code == 0
 
-        result = runner.invoke(versioning, ["--path", project_path, "--repo-path", REPO_PATH,
-                                            "--compare", "pytest/test_bad_version"])
+        result = runner.invoke(
+            versioning, ["--path", project_path, "--repo-path", REPO_PATH, "--compare", "pytest/test_bad_version"]
+        )
         print(result.output)
         assert result.exit_code == 1
-
 
     def test_versioning_bump_target(self):
         project_path = os.path.join(RESOURCES_PATH, "HelloWorld")
 
         runner = CliRunner()
-        result = runner.invoke(versioning, ["--path", project_path, "--repo-path", REPO_PATH,
-                                            "--compare", "pytest/test_big_version",
-                                            "--bump", "patch"])
+        result = runner.invoke(
+            versioning,
+            [
+                "--path",
+                project_path,
+                "--repo-path",
+                REPO_PATH,
+                "--compare",
+                "pytest/test_big_version",
+                "--bump",
+                "patch",
+            ],
+        )
         print(result.output)
         assert result.exit_code == 0
         pbt_version = VersioningTestCase._get_pbt_version(project_path)
         assert pbt_version == "9999.0.1"
 
-        result = runner.invoke(versioning, ["--path", project_path, "--repo-path", REPO_PATH,
-                                            "--compare", "pytest/test_small_version",
-                                            "--bump", "patch"])
+        result = runner.invoke(
+            versioning,
+            [
+                "--path",
+                project_path,
+                "--repo-path",
+                REPO_PATH,
+                "--compare",
+                "pytest/test_small_version",
+                "--bump",
+                "patch",
+            ],
+        )
         print(result.output)
         assert result.exit_code == 0
         assert pbt_version == "9999.0.1"
-
 
     def test_versioning_make_unique(self):
         project_path = os.path.join(RESOURCES_PATH, "HelloWorld")
 
         runner = CliRunner()
-        result = runner.invoke(versioning, ["--path", project_path, "--repo-path", REPO_PATH,
-                                            "--make-unique"])
+        result = runner.invoke(versioning, ["--path", project_path, "--repo-path", REPO_PATH, "--make-unique"])
         print(result.output)
         assert result.exit_code == 0
         pbt_version = VersioningTestCase._get_pbt_version(project_path)
         assert pbt_version == "0.0.1-dev+sha.612978c2"
-
-

--- a/test/test_versioning.py
+++ b/test/test_versioning.py
@@ -197,15 +197,18 @@ class VersioningTestCase(unittest.TestCase):
 
         runner = CliRunner()
         result = runner.invoke(versioning, ["--path", project_path, "--repo-path", REPO_PATH,
-                                            "--compare", "pytest_big_version"])
+                                            "--compare", "pytest/test_big_version"])
+        print(result.output)
         assert result.exit_code == 1
 
         result = runner.invoke(versioning, ["--path", project_path, "--repo-path", REPO_PATH,
-                                            "--compare", "pytest_small_version"])
+                                            "--compare", "pytest/test_small_version"])
+        print(result.output)
         assert result.exit_code == 0
 
         result = runner.invoke(versioning, ["--path", project_path, "--repo-path", REPO_PATH,
-                                            "--compare", "pytest_bad_version"])
+                                            "--compare", "pytest/test_bad_version"])
+        print(result.output)
         assert result.exit_code == 0
 
         

--- a/test/test_versioning.py
+++ b/test/test_versioning.py
@@ -175,15 +175,14 @@ class VersioningTestCase(unittest.TestCase):
     def test_versioning_version_check_sync_python(self):
         project_path = os.path.join(RESOURCES_PATH, "HelloWorld")
 
-        with open(os.path.join(project_path, "pipelines/customers_orders/code/setup.py"), 'r') as fd:
+        with open(os.path.join(project_path, "pipelines/customers_orders/code/setup.py"), "r") as fd:
             content = fd.read()
 
         content = content.replace("version = '1.0'", "version = '999.0'")
 
-        with open(os.path.join(project_path, "pipelines/customers_orders/code/setup.py"), 'w') as fd:
+        with open(os.path.join(project_path, "pipelines/customers_orders/code/setup.py"), "w") as fd:
             fd.write(content)
 
         runner = CliRunner()
-        result = runner.invoke(versioning, ["--path", project_path, '--check-sync'])
+        result = runner.invoke(versioning, ["--path", project_path, "--check-sync"])
         assert result.exit_code == 0
-


### PR DESCRIPTION
adds helpers to the `versioning` subcommand:

`--check-sync`: checks to see if versions are synchronized. return 0 success or 1 fail.
`--make-unique`: adds prerelease candidate and build metadata to differentiate version for working on feature branches (if users need to deploy artifacts simultaneously in dev environment) 
`--compare`: compare current version to version in another target branch. return 0 success or 1 fail. If combined with the `--bump` option then it will use that strategy to bump the current version past the target. 

also renames `--set-prerelease` to `--set-suffix` as the suffix can also hold build data. AFAIK this flag is brand new and not documented yet, so it's unlikely anyone has adopted it for so long it can't be updated. 