### PR TITLE
Upgrade google-cloud-secret-manager 2.22.x

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ pycodestyle==2.10.0
 google-cloud-storage==2.10.0
 pydantic~=1.10
 pydantic-yaml==1.1.1
-google-cloud-secret-manager==2.16.2 # similiar to what we have in execution service.
+google-cloud-secret-manager~=2.22.0 # similiar to what we have in execution service.
 boto3~=1.34.120
 requests~=2.32.3
 tenacity==8.2.3

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setuptools.setup(
         "rich>=12.5.1",
         "wheel",
         "build",
-        "google-cloud-secret-manager==2.16.2",
+        "google-cloud-secret-manager~=2.22.0",
         "google-cloud-storage==2.10.0",
         "pydantic~=1.10",
         "pydantic-yaml==1.1.1",


### PR DESCRIPTION
When trying to upgrade Prophecy's internal DBT version, the secret manager's current version causes issues due to conflict in requiring different version of protobuf package.
To fix this problem, this diff upgrades google-cloud-secret-manager version for pbt.