### PR TITLE
Rj/update java17 for ubuntu latest ghrunner

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,10 +169,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
-          java-version: '11'
+          java-version: '17'
           distribution: 'adopt'
       - name: Set up Python 3.x
         uses: actions/setup-python@v4

--- a/src/pbt/deployment/gems.py
+++ b/src/pbt/deployment/gems.py
@@ -94,7 +94,7 @@ class PackageBuilder:
         env = dict(os.environ)
 
         # Set the MAVEN_OPTS variable
-        env["MAVEN_OPTS"] = "-Xmx1024m -XX:MaxPermSize=512m -Xss32m"
+        env["MAVEN_OPTS"] = "-Xmx1024m -XX:MaxMetaspaceSize=512m -Xss32m"
 
         process = subprocess.Popen(
             command, shell=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=env, cwd=self.path

--- a/src/pbt/deployment/pipeline.py
+++ b/src/pbt/deployment/pipeline.py
@@ -683,7 +683,7 @@ class PackageBuilderAndUploader:
         env = dict(os.environ)
 
         # Set the MAVEN_OPTS variable
-        env["MAVEN_OPTS"] = "-Xmx1024m -XX:MaxPermSize=512m -Xss32m"
+        env["MAVEN_OPTS"] = "-Xmx1024m -XX:MaxMetaspaceSize=512m -Xss32m"
 
         if env.get("FABRIC_NAME", None) is None:
             env["FABRIC_NAME"] = "default"  # for python test runs.

--- a/test/test_versioning.py
+++ b/test/test_versioning.py
@@ -10,8 +10,7 @@ from parameterized import parameterized
 CURRENT_DIRECTORY = os.path.dirname(os.path.abspath(__file__))
 REPO_PATH = os.path.dirname(CURRENT_DIRECTORY)
 PROJECT_PATH = CURRENT_DIRECTORY + "/resources/HelloWorld"
-# PROJECTS_TO_TEST = ["HelloWorld", "BaseDirectory", "ProjectCreatedOn160523"]
-PROJECTS_TO_TEST = ["HelloWorld", "BaseDirectory"]
+PROJECTS_TO_TEST = ["HelloWorld", "BaseDirectory", "ProjectCreatedOn160523"]
 RESOURCES_PATH = os.path.join(CURRENT_DIRECTORY, "resources")
 
 


### PR DESCRIPTION
ubuntu runners started using ubuntu 24.04 in late Dec 2024. this upgraded default java to jdk 17 which deprecated some options that we were using. 

https://github.com/actions/runner-images/issues/10636

upgraded maxPermSize to MaxMetaspaceSize according to https://docs.oracle.com/en/java/javase/17/docs/specs/man/java.html

