### PR TITLE
now skip builds only skips building artifacts, does not skip uploading. fixes #144

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as _in:
 
 setuptools.setup(
     name="prophecy-build-tool",
-    version="1.2.50",
+    version="1.2.51",
     author="Prophecy",
     author_email="maciej@prophecy.io",
     description="Prophecy-build-tool (PBT) provides utilities to build and distribute projects created from the "

--- a/src/pbt/__init__.py
+++ b/src/pbt/__init__.py
@@ -214,6 +214,13 @@ def deploy(
     default="",
 )
 @click.option("--skip-builds", default=False, is_flag=True, help="Flag to skip building Pipelines", required=False)
+@click.option(
+    "--skip-pipeline-deploy",
+    default=False,
+    is_flag=True,
+    help="Flag to skip deploying Pipelines (only deploys job definitions)",
+    required=False,
+)
 @click.option("--dependent-projects-path", default="", help="Dependent projects path", required=False)
 @click.option("--migrate", default=False, is_flag=True, help="Migrate v1 to v2 based project", required=False)
 @click.option(
@@ -239,6 +246,7 @@ def deploy_v2(
     fabric_ids: str,
     job_ids: str,
     skip_builds: bool,
+    skip_pipeline_deploy: bool,
     dependent_projects_path: str,
     migrate: bool,
     artifactory: str,
@@ -253,6 +261,7 @@ def deploy_v2(
         fabric_ids,
         job_ids,
         skip_builds,
+        skip_pipeline_deploy,
         dependent_projects_path,
         migrate,
         artifactory,

--- a/src/pbt/deployment/pipeline.py
+++ b/src/pbt/deployment/pipeline.py
@@ -490,15 +490,11 @@ class PackageBuilderAndUploader:
         if pipeline_from_nexus is not None and pipeline_from_nexus.is_right:
             return Either(right=(self._pipeline_id, pipeline_from_nexus.right))
 
-        if not is_online_mode() and self._project_config.skip_builds:
-            log("Artifact File already exist, ignoring pipeline build", step_id=self._pipeline_id, indent=2)
-            return Either(right=True)
-
         # trying to build and deploy
         try:
             if not is_online_mode() and self._project_config.skip_builds:
                 log(
-                    "Artifact File already exist or --skip-builds set, ignoring pipeline build",
+                    "Artifact File already exists or --skip-builds set, ignoring pipeline build",
                     step_id=self._pipeline_id,
                     indent=2,
                 )

--- a/src/pbt/deployment/pipeline.py
+++ b/src/pbt/deployment/pipeline.py
@@ -496,18 +496,29 @@ class PackageBuilderAndUploader:
 
         # trying to build and deploy
         try:
-            self._initialize_temp_folder()
-
-            log("Initialized temp folder for building the pipeline package.", step_id=self._pipeline_id, indent=2)
-
-            if self._project_language == SCALA_LANGUAGE:
-                self.mvn_build()
+            if not is_online_mode() and self._project_config.skip_builds:
+                log(
+                    "Artifact File already exist or --skip-builds set, ignoring pipeline build",
+                    step_id=self._pipeline_id,
+                    indent=2,
+                )
             else:
-                self.wheel_build()
+                self._initialize_temp_folder()
+                log("Initialized temp folder for building the pipeline package.", step_id=self._pipeline_id, indent=2)
+
+                if self._project_language == SCALA_LANGUAGE:
+                    self.mvn_build()
+                else:
+                    self.wheel_build()
+                log(
+                    f"{Colors.OKGREEN}Pipeline package built successfully{Colors.ENDC}\n",
+                    step_id=self._pipeline_id,
+                    indent=2,
+                )
 
             path = Project.get_pipeline_whl_or_jar(self._base_path)
             log(
-                f"{Colors.OKGREEN}Pipeline package built successfully, with path {path}{Colors.ENDC}\n",
+                f"{Colors.OKBLUE}Pipeline package path: {path}{Colors.ENDC}\n",
                 step_id=self._pipeline_id,
                 indent=2,
             )

--- a/src/pbt/deployment/project.py
+++ b/src/pbt/deployment/project.py
@@ -200,7 +200,7 @@ class ProjectDeployment:
         if not self.project_config.skip_pipeline_deploy:
             self._deploy_pipelines()
         else:
-            log("\nSkipping pipeline deployment as skip_builds is set to true.\n")
+            log("\nSkipping pipeline deployment as --skip-pipeline-deploy is set to true.\n")
 
         databricks_responses = self._deploy_databricks_jobs()
         airflow_responses = self._deploy_airflow_jobs()

--- a/src/pbt/deployment/project.py
+++ b/src/pbt/deployment/project.py
@@ -197,7 +197,7 @@ class ProjectDeployment:
         self._deploy_emr_pipeline_config()
         self._deploy_dataproc_pipeline_config()
 
-        if not self.project_config.skip_builds:
+        if not self.project_config.skip_pipeline_deploy:
             self._deploy_pipelines()
         else:
             log("\nSkipping pipeline deployment as skip_builds is set to true.\n")

--- a/src/pbt/deployment/uploader/PipelineUploaderManager.py
+++ b/src/pbt/deployment/uploader/PipelineUploaderManager.py
@@ -31,8 +31,9 @@ class PipelineUploadManager(PipelineUploader, ABC):
     def upload_pipeline(self, from_path: str):
         try:
             if from_path is None:
-                raise Exception(f"Pipeline upload failed {self.pipeline_id}. "
-                                f"run again without --skip-builds to build pipelines")
+                raise Exception(
+                    f"Pipeline upload failed {self.pipeline_id}. " f"run again without --skip-builds to build pipelines"
+                )
 
             file_name_with_extension = os.path.basename(from_path)
 

--- a/src/pbt/deployment/uploader/PipelineUploaderManager.py
+++ b/src/pbt/deployment/uploader/PipelineUploaderManager.py
@@ -31,7 +31,8 @@ class PipelineUploadManager(PipelineUploader, ABC):
     def upload_pipeline(self, from_path: str):
         try:
             if from_path is None:
-                raise Exception(f"Pipeline build failed {self.pipeline_id}")
+                raise Exception(f"Pipeline upload failed {self.pipeline_id}. "
+                                f"run again without --skip-builds to build pipelines")
 
             file_name_with_extension = os.path.basename(from_path)
 

--- a/src/pbt/pbt_cli.py
+++ b/src/pbt/pbt_cli.py
@@ -40,6 +40,7 @@ class PBTCli(object):
         fabric_ids: str = "",
         job_ids: str = "",
         skip_builds: bool = False,
+        skip_pipeline_deploy: bool = False,
         dependant_project_paths: str = "",
         migrate: bool = False,
         artifactory: str = "",
@@ -48,7 +49,15 @@ class PBTCli(object):
         """Create PBTCli from conf folder."""
         project = Project(project_path, project_id, release_tag, release_version, dependant_project_paths)
         project_config = ProjectConfig.from_conf_folder(
-            project, conf_folder, fabric_ids, job_ids, skip_builds, migrate, artifactory, skip_artifactory_upload
+            project,
+            conf_folder,
+            fabric_ids,
+            job_ids,
+            skip_builds,
+            skip_pipeline_deploy,
+            migrate,
+            artifactory,
+            skip_artifactory_upload,
         )
         return cls(project, project_config)
 

--- a/src/pbt/utils/project_config.py
+++ b/src/pbt/utils/project_config.py
@@ -529,6 +529,7 @@ class ProjectConfig:
         config_override: ConfigsOverride,
         based_on_file: bool = True,
         skip_builds: bool = False,
+        skip_pipeline_deploy: bool = False,
         migrate: bool = False,
         artifactory: str = "",
         skip_artifactory_upload: bool = False,
@@ -539,6 +540,7 @@ class ProjectConfig:
         self.configs_override = config_override
         self.based_on_file = based_on_file
         self.skip_builds = skip_builds
+        self.skip_pipeline_deploy = skip_pipeline_deploy
         self.migrate = migrate
         self.artifactory = artifactory
         self.skip_artifactory_upload = skip_artifactory_upload
@@ -578,6 +580,7 @@ class ProjectConfig:
         fabric_ids: str,
         job_ids: str,
         skip_build: bool,
+        skip_pipeline_deploy: bool,
         conf_folder: str,
         migrate: bool,
         artifactory: str,
@@ -654,6 +657,7 @@ class ProjectConfig:
                 configs,
                 based_on_file=is_based_on_file,
                 skip_builds=skip_build,
+                skip_pipeline_deploy=skip_pipeline_deploy,
                 migrate=migrate,
                 artifactory=artifactory,
                 skip_artifactory_upload=skip_artifactory_upload,
@@ -668,6 +672,7 @@ class ProjectConfig:
         fabric_ids: str,
         job_ids: str,
         skip_builds: bool,
+        skip_pipeline_deploy: bool,
         migrate: bool,
         artifactory: str,
         skip_artifactory_upload: bool,
@@ -686,6 +691,7 @@ class ProjectConfig:
             fabric_ids,
             job_ids,
             skip_builds,
+            skip_pipeline_deploy,
             conf_folder,
             migrate,
             artifactory,


### PR DESCRIPTION
we will change the behavior of `--skip-builds` so that it skips the build step of JAR/WHL files, but it does not skip uploading those files to dbfs/volumes/artifactory

to accommodate legacy behavior we will make a new option called `--skip-pipeline-upload` which skips both building and uploading (the legacy behavior) 

these changes will affect deploy-v2 only. 