### PR TITLE
Rj/remove check sync on compare ver

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as _in:
 
 setuptools.setup(
     name="prophecy-build-tool",
-    version="1.2.51",
+    version="1.2.52",
     author="Prophecy",
     author_email="maciej@prophecy.io",
     description="Prophecy-build-tool (PBT) provides utilities to build and distribute projects created from the "

--- a/src/pbt/__init__.py
+++ b/src/pbt/__init__.py
@@ -1,6 +1,7 @@
 """
 DATABRICKS_HOST, DATABRICKS_TOKEN
 """
+
 import sys
 from typing import Optional
 

--- a/src/pbt/__init__.py
+++ b/src/pbt/__init__.py
@@ -427,9 +427,6 @@ def versioning(path, repo_path, bump, set, force, sync, set_suffix, check_sync, 
             else:
                 # when bump is not given, then just return 0 or 1 to compare versions
                 sys.exit(1)
-        else:
-            # always if our version is already higher, make sure we are sync'd.
-            pbt.version_check_sync()
     elif make_unique:
         pbt.version_make_unique(repo_path, force=True)
     else:

--- a/src/pbt/deployment/__init__.py
+++ b/src/pbt/deployment/__init__.py
@@ -25,7 +25,7 @@ class EntityIdToFabricId:
 
 
 def invert_entity_to_fabric_mapping(
-    entity_id_dict: Dict[str, List[EntityIdToFabricId]]
+    entity_id_dict: Dict[str, List[EntityIdToFabricId]],
 ) -> Dict[str, List[EntityIdToFabricId]]:
     result = {}
 

--- a/src/pbt/deployment/jobs/utils.py
+++ b/src/pbt/deployment/jobs/utils.py
@@ -43,7 +43,7 @@ def modify_databricks_json_for_private_artifactory(data, artifactory=None):
                             {
                                 "pypi": {
                                     "package": f"{package_name}=={package_version}",
-                                    "repo": f"{artifactory.rstrip('/')}/simple"  # adding as pip uses simple api
+                                    "repo": f"{artifactory.rstrip('/')}/simple",  # adding as pip uses simple api
                                     # for downloading packages
                                 }
                             }


### PR DESCRIPTION
The `pbt versioning --compare $target` command should not perform `pbt versioning --check-sync` at the end of its logic during a successful comparison. 

The `compare` func should _only_ be used to compare pbt_project.yml versions. If user wants to check to see if version is sync'd within the repo that is a separate command that we have `--check-sync` and can perform with a second invocation to pbt. 

