### PR TITLE
versioning `--only-pbt` option

### DIFF
--- a/src/pbt/__init__.py
+++ b/src/pbt/__init__.py
@@ -1,6 +1,7 @@
 """
 DATABRICKS_HOST, DATABRICKS_TOKEN
 """
+
 import sys
 from typing import Optional
 
@@ -380,13 +381,14 @@ def test(path, driver_library_path, pipelines):
 @click.option(
     "--pbt-only",
     help="apply version operation to pbt_project.yml file only. applicable in combination with: "
-         "--compare, --make-unique, --bump, --set, --set-suffix",
+    "--compare, --make-unique, --bump, --set, --set-suffix",
     default=False,
     is_flag=True,
     required=False,
 )
-def versioning(path, repo_path, bump, set, force, sync, set_suffix, check_sync, compare_to_target, make_unique,
-               pbt_only):
+def versioning(
+    path, repo_path, bump, set, force, sync, set_suffix, check_sync, compare_to_target, make_unique, pbt_only
+):
     pbt = PBTCli.from_conf_folder(path)
     if not repo_path:
         repo_path = path

--- a/src/pbt/__init__.py
+++ b/src/pbt/__init__.py
@@ -377,7 +377,16 @@ def test(path, driver_library_path, pipelines):
     is_flag=True,
     required=False,
 )
-def versioning(path, repo_path, bump, set, force, sync, set_suffix, check_sync, compare_to_target, make_unique):
+@click.option(
+    "--pbt-only",
+    help="apply version operation to pbt_project.yml file only. applicable in combination with: "
+         "--compare, --make-unique, --bump, --set, --set-suffix",
+    default=False,
+    is_flag=True,
+    required=False,
+)
+def versioning(path, repo_path, bump, set, force, sync, set_suffix, check_sync, compare_to_target, make_unique,
+               pbt_only):
     pbt = PBTCli.from_conf_folder(path)
     if not repo_path:
         repo_path = path
@@ -404,13 +413,13 @@ def versioning(path, repo_path, bump, set, force, sync, set_suffix, check_sync, 
             )
 
     if set:
-        pbt.version_set(set, force)
+        pbt.version_set(set, force, pbt_only)
     elif bump and not compare_to_target:
-        pbt.version_bump(bump, force)
+        pbt.version_bump(bump, force, pbt_only)
     elif sync:
-        pbt.version_set(None, force)
+        pbt.version_set(None, force, pbt_only)
     elif set_suffix:
-        pbt.version_set_suffix(set_suffix, force)
+        pbt.version_set_suffix(set_suffix, force, pbt_only)
     elif check_sync:
         pbt.version_check_sync()
     elif compare_to_target:
@@ -423,7 +432,7 @@ def versioning(path, repo_path, bump, set, force, sync, set_suffix, check_sync, 
                     bump,
                     pbt.project.project.pbt_project_dict["language"],
                 )
-                pbt.version_set(new_version, force=True)
+                pbt.version_set(new_version, force=True, pbt_only=pbt_only)
             else:
                 # when bump is not given, then just return 0 or 1 to compare versions
                 sys.exit(1)
@@ -431,7 +440,7 @@ def versioning(path, repo_path, bump, set, force, sync, set_suffix, check_sync, 
             # always if our version is already higher, make sure we are sync'd.
             pbt.version_check_sync()
     elif make_unique:
-        pbt.version_make_unique(repo_path, force=True)
+        pbt.version_make_unique(repo_path, force=True, pbt_only=pbt_only)
     else:
         raise click.UsageError(
             "must give ONE of: '--set', '--bump', '--sync', '--check-sync', '--set-prerelease', "

--- a/src/pbt/deployment/__init__.py
+++ b/src/pbt/deployment/__init__.py
@@ -25,7 +25,7 @@ class EntityIdToFabricId:
 
 
 def invert_entity_to_fabric_mapping(
-    entity_id_dict: Dict[str, List[EntityIdToFabricId]]
+    entity_id_dict: Dict[str, List[EntityIdToFabricId]],
 ) -> Dict[str, List[EntityIdToFabricId]]:
     result = {}
 

--- a/src/pbt/deployment/jobs/utils.py
+++ b/src/pbt/deployment/jobs/utils.py
@@ -43,7 +43,7 @@ def modify_databricks_json_for_private_artifactory(data, artifactory=None):
                             {
                                 "pypi": {
                                     "package": f"{package_name}=={package_version}",
-                                    "repo": f"{artifactory.rstrip('/')}/simple"  # adding as pip uses simple api
+                                    "repo": f"{artifactory.rstrip('/')}/simple",  # adding as pip uses simple api
                                     # for downloading packages
                                 }
                             }

--- a/src/pbt/entities/project.py
+++ b/src/pbt/entities/project.py
@@ -422,13 +422,14 @@ class Project:
 
         return False
 
-    def update_version(self, new_version, force=False):
+    def update_version(self, new_version, force=False, pbt_only=False):
         update_all_versions(
             self.project_path,
             self.project_language,
             orig_project_version=self.pbt_project_dict["version"],
             new_version=new_version,
             force=force,
+            pbt_only=pbt_only
         )
         # update our internal reference in case calls get chained which use this field.
         self.pbt_project_dict["version"] = new_version

--- a/src/pbt/entities/project.py
+++ b/src/pbt/entities/project.py
@@ -429,7 +429,7 @@ class Project:
             orig_project_version=self.pbt_project_dict["version"],
             new_version=new_version,
             force=force,
-            pbt_only=pbt_only
+            pbt_only=pbt_only,
         )
         # update our internal reference in case calls get chained which use this field.
         self.pbt_project_dict["version"] = new_version

--- a/src/pbt/pbt_cli.py
+++ b/src/pbt/pbt_cli.py
@@ -87,24 +87,24 @@ class PBTCli(object):
     def validate(self, treat_warnings_as_errors: bool):
         self.project.validate(treat_warnings_as_errors)
 
-    def version_bump(self, bump_type, force):
+    def version_bump(self, bump_type, force, pbt_only):
         new_version = get_bumped_version(
             self.project.project.pbt_project_dict["version"],
             bump_type,
             self.project.project.pbt_project_dict["language"],
         )
         log(f"Bumping {bump_type}. New version: {new_version}")
-        self.project.project.update_version(new_version=new_version, force=force)
+        self.project.project.update_version(new_version=new_version, force=force, pbt_only=pbt_only)
         log("Success.")
 
-    def version_set(self, version, force):
+    def version_set(self, version, force, pbt_only):
         if version is None:
             # sync option will send None, so take existing version.
             version = self.project.project.pbt_project_dict["version"]
             force = True
-        self.project.project.update_version(new_version=version, force=force)
+        self.project.project.update_version(new_version=version, force=force, pbt_only=pbt_only)
 
-    def version_set_suffix(self, suffix, force):
+    def version_set_suffix(self, suffix, force, pbt_only):
         if not semver.Version.is_valid(self.project.project.pbt_project_dict["version"]):
             print("ERROR: current version is not in semVer syntax. cannot proceed.")
             sys.exit(1)
@@ -113,7 +113,7 @@ class PBTCli(object):
         if not semver.Version.is_valid(new_version_str) and not force:
             print("ERROR: suffix provided is not valid semVer syntax. You can use --force to ignore this.")
             sys.exit(1)
-        self.version_set(new_version_str, force)
+        self.version_set(new_version_str, force, pbt_only)
 
     def version_check_sync(self):
         version_check_sync(
@@ -122,14 +122,14 @@ class PBTCli(object):
             self.project.project.pbt_project_dict["version"],
         )
 
-    def version_make_unique(self, repo_path, force):
+    def version_make_unique(self, repo_path, force, pbt_only):
         repo = git.Repo(repo_path)
         branch_name = repo.active_branch.name
         branch_hash = hashlib.sha256(branch_name.encode()).hexdigest()[:8]
         if self.project.project.project_language == SCALA_LANGUAGE:
-            self.version_set_suffix(f"-SNAPSHOT+sha.{branch_hash}", force)
+            self.version_set_suffix(f"-SNAPSHOT+sha.{branch_hash}", force, pbt_only)
         else:
-            self.version_set_suffix(f"-dev+sha.{branch_hash}", force)
+            self.version_set_suffix(f"-dev+sha.{branch_hash}", force, pbt_only)
 
     def version_get_target_branch_version(self, repo_path, target_branch):
         repo = git.Repo(repo_path)


### PR DESCRIPTION
for the versioning suite we should give the users a new option to only apply version operations to the pbt_project.yml file 


reason: the prophecy UI will autogenerate the code and overwrite any artifact-files (pom.xml, setup.py) which contain versions. Therefore customers may want to have a step in their CI/CD pipeline which updates pbt_project.yml separately to commit the changes back without affecting all other files which may get rewritten in the UI. (then users can use `--sync` option later before building / deploying artifacts) 



this is purely a new option which is off by default. default behavior remains the same for all other cases. 