### PR TITLE
PEP440 automatically uses -dev0 instead of -dev by default. Fixing to follow PEP440…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as _in:
 
 setuptools.setup(
     name="prophecy-build-tool",
-    version="1.2.52",
+    version="1.2.53",
     author="Prophecy",
     author_email="maciej@prophecy.io",
     description="Prophecy-build-tool (PBT) provides utilities to build and distribute projects created from the "

--- a/src/pbt/__init__.py
+++ b/src/pbt/__init__.py
@@ -381,7 +381,7 @@ def test(path, driver_library_path, pipelines):
     " deprioritize this version from being chosen over other versions (recommended so that it does not "
     " accidentally get chosen over a real release. "
     " \nformat: MAJOR.MINOR.PATCH-PRERELEASE+BUILDMETADATA"
-    " \npython example: 3.3.0 -> 3.3.0-dev+sha.j0239ruf0ew"
+    " \npython example: 3.3.0 -> 3.3.0-dev0+sha.j0239ruf0ew"
     " \nscala example: 3.3.0 -> 3.3.0-SNAPSHOT+sha.j0239ruf0ew",
     default=False,
     is_flag=True,

--- a/src/pbt/pbt_cli.py
+++ b/src/pbt/pbt_cli.py
@@ -138,7 +138,7 @@ class PBTCli(object):
         if self.project.project.project_language == SCALA_LANGUAGE:
             self.version_set_suffix(f"-SNAPSHOT+sha.{branch_hash}", force, pbt_only)
         else:
-            self.version_set_suffix(f"-dev+sha.{branch_hash}", force, pbt_only)
+            self.version_set_suffix(f"-dev0+sha.{branch_hash}", force, pbt_only)
 
     def version_get_target_branch_version(self, repo_path, target_branch):
         repo = git.Repo(repo_path)

--- a/src/pbt/utils/versioning.py
+++ b/src/pbt/utils/versioning.py
@@ -73,7 +73,7 @@ def update_all_versions(project_path, project_language, orig_project_version, ne
             new_content = pattern.sub(replacement_string, content, count=count)
             with open(file, "w") as fd:
                 fd.write(new_content)
-                log(f"[UPDATE]{replacement_string} updated in {file}")
+                log(f"[UPDATE] {replacement_string} updated in {file}")
 
     def _update_whl_version_in_databricks_json(file_paths, new_version):
         """
@@ -83,14 +83,22 @@ def update_all_versions(project_path, project_language, orig_project_version, ne
             file_paths (list): List of JSON file paths to update.
             new_version (str): The new version to set in the .whl paths.
         """
-        # Regex pattern to find the .whl paths with version
-        whl_version_pattern = r"-(\d+\.\d+)-py3-none-any\.whl"
+        if project_language == "python":
+            # Regex pattern to find the .whl paths with version
+            whl_version_pattern = r"-([^-]+)-py3-none-any\.whl"
 
-        # Replacement pattern with the new version
-        replacement_string = f"-{new_version}-py3-none-any.whl"
+            # Replacement pattern with the new version
+            replacement_string = f"-{new_version}-py3-none-any.whl"
 
-        # Call the existing _replace_in_files method
-        _replace_in_files(whl_version_pattern, replacement_string, file_paths, count=0)  # replace all occurences
+            # Call the existing _replace_in_files method
+            _replace_in_files(whl_version_pattern, replacement_string, file_paths, count=0)  # replace all occurences
+        elif project_language == "scala":
+            pass
+            # there is no version in this artifact name. but do we need to replace it in the path? or is it already being replaced?
+            #       "path" : "dbfs:/FileStore/prophecy/artifacts/saas/app/__PROJECT_ID_PLACEHOLDER__/__PROJECT_RELEASE_VERSION_PLACEHOLDER__/pipeline/raw_bronze.jar",
+        elif project_language == "sql":
+            pass
+            # just deploys dbt_script.py under latest.... not sure whether to change this behavior.
 
     # PBT project
     pbt_project_file = os.path.join(project_path, "pbt_project.yml")

--- a/test/test_versioning.py
+++ b/test/test_versioning.py
@@ -305,7 +305,7 @@ class VersioningTestCase(unittest.TestCase):
             print(result.output)
             assert result.exit_code == 0
             pbt_version = VersioningTestCase._get_pbt_version(project_path)
-            assert pbt_version == "0.0.1-dev+sha.062f87eb"
+            assert pbt_version == "0.0.1-dev0+sha.062f87eb"
         finally:
             self.reset_changed_files("test/resources/")
             self.repo.git.checkout(self.orig_repo_head)


### PR DESCRIPTION
… 

also changing regex slightly to look for any version, not just "1.0" in databricks job json