### PR TITLE
adding setuptools requirement to setup.py and fixing tests to not use requirements.txt

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -32,6 +32,11 @@ jobs:
         python -m pip install --upgrade pip
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
         pip install ".[test]"
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+        pip install ".[test]"
     - name: Lint with Black
       run: |
         # stop the build if there are Python syntax errors or undefined names

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -27,22 +27,21 @@ jobs:
       uses: actions/setup-python@v3
       with:
         python-version: '3.8'
-    - name: Install dependencies
+    - name: Build package
+      run: |
+        pip install build
+        python -m build
+    - name: Install package
       run: |
         python -m pip install --upgrade pip
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-        pip install ".[test]"
-        pip install build
+        pip install "./dist/$(ls ./dist/ | grep whl)[test]"
     - name: Lint with Black
       run: |
         # stop the build if there are Python syntax errors or undefined names
         black --check src/ test/
-
     - name: Test with pytest
       run: |
         python -m pytest test/test_* -v
-    - name: Build package
-      run: python -m build
     - name: Publish package
       uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
       with:

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as _in:
 
 setuptools.setup(
     name="prophecy-build-tool",
-    version="1.2.57",
+    version="1.2.58",
     author="Prophecy",
     author_email="maciej@prophecy.io",
     description="Prophecy-build-tool (PBT) provides utilities to build and distribute projects created from the "
@@ -38,6 +38,7 @@ setuptools.setup(
         "tenacity==8.2.3",
         "gitpython",
         "semver",
+        "setuptools>=75.3.2",
         "twine",
         "jaraco.functools<=4.1.0"
     ],


### PR DESCRIPTION
setuptools requirement was set in requirements.txt instead of setup.py which is used by packaging system to define `install_requires`