### PR TITLE
fix: stop leaking fabric tokens/secrets in deployment error messages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as _in:
 
 setuptools.setup(
     name="prophecy-build-tool",
-    version="1.4.3",
+    version="1.4.4",
     author="Prophecy",
     author_email="maciej@prophecy.io",
     description="Prophecy-build-tool (PBT) provides utilities to build and distribute projects created from the "

--- a/src/pbt/client/rest_client_factory.py
+++ b/src/pbt/client/rest_client_factory.py
@@ -25,7 +25,11 @@ class RestClientFactory:
         else:
             fabric_info: Optional[FabricInfo] = self.fabric_config.get_fabric(str(fabric_id))
             if fabric_info is None:
-                raise ValueError(f"Fabric Id {fabric_id} is not found in the fabric configs {self.fabric_config}")
+                # never interpolate the fabric config, it carries tokens and lands in the deployment logs.
+                raise ValueError(
+                    f"Fabric Id {fabric_id} is not found in the fabric configs. "
+                    f"Available fabric ids: {self.fabric_config.list_all_fabrics()}"
+                )
             return fabric_info
 
     def _get_client(self, fabric_id: str):
@@ -58,7 +62,8 @@ class RestClientFactory:
         if self._get_client(fabric_id) is not None:
             return self._get_client(fabric_id)
 
-        databricks = self._get_fabric_info(fabric_id).databricks
+        fabric_info = self._get_fabric_info(fabric_id)
+        databricks = fabric_info.databricks
 
         if databricks is not None:
             oauth_client_secret = (
@@ -76,7 +81,8 @@ class RestClientFactory:
 
         else:
             raise ValueError(
-                f"Fabric Id {fabric_id} is not defined and the databricks client {self._get_fabric_info(fabric_id)}."
+                f"Fabric Id {fabric_id} (name '{fabric_info.name}', provider {fabric_info.provider}) "
+                f"does not have a databricks configuration defined."
             )
 
     def airflow_client(self, fabric_id: str) -> AirflowRestClient:

--- a/test/test_error_message_secrets.py
+++ b/test/test_error_message_secrets.py
@@ -1,0 +1,155 @@
+import pytest
+
+from src.pbt.client.rest_client_factory import RestClientFactory
+from src.pbt.utils.project_config import (
+    ComposerInfo,
+    DatabricksInfo,
+    DataprocInfo,
+    EMRInfo,
+    FabricConfig,
+    FabricInfo,
+    FabricProviderType,
+    FabricType,
+    MwaaInfo,
+    OAuthCredentials,
+    OpenSourceAirflowInfo,
+    ProjectAndGitTokens,
+)
+
+SECRET_VALUES = [
+    "dapi-secret-databricks-token",
+    "secret-oauth-client-secret",
+    "secret-emr-access-key-id",
+    "secret-emr-secret-access-key",
+    "secret-emr-session-token",
+    "secret-mwaa-access-key",
+    "secret-mwaa-secret-key",
+    "secret-airflow-password",
+    "secret-uploader-password",
+    "secret-composer-key-json",
+    "secret-dataproc-key-json",
+    "secret-git-token",
+]
+
+
+def build_fabric_config():
+    return FabricConfig(
+        fabrics=[
+            FabricInfo(
+                id="12038",
+                name="dev_databricks_unified_fabric",
+                type=FabricType.Sql,
+                provider=FabricProviderType.Databricks,
+                databricks=DatabricksInfo(
+                    url="https://test.cloud.databricks.com",
+                    token="dapi-secret-databricks-token",
+                    auth_type="oauth",
+                    user_agent="Prophecy",
+                    oauth_credentials=OAuthCredentials(
+                        client_id="test-client-id", client_secret="secret-oauth-client-secret"
+                    ),
+                ),
+            ),
+            FabricInfo(
+                id="555",
+                name="emr_fabric",
+                type=FabricType.Spark,
+                provider=FabricProviderType.EMR,
+                emr=EMRInfo(
+                    region="us-east-1",
+                    bucket="s3://test-bucket/prefix",
+                    access_key_id="secret-emr-access-key-id",
+                    secret_access_key="secret-emr-secret-access-key",
+                    session_token="secret-emr-session-token",
+                ),
+            ),
+            FabricInfo(
+                id="666",
+                name="mwaa_fabric",
+                type=FabricType.Airflow,
+                provider=FabricProviderType.MWAA,
+                mwaa=MwaaInfo(
+                    region="us-east-1",
+                    version="2.5.1",
+                    access_key="secret-mwaa-access-key",
+                    secret_key="secret-mwaa-secret-key",
+                    airflow_url="https://mwaa.test",
+                    dag_location="s3://dags",
+                    environment_name="test-env",
+                    assumed_role=None,
+                    custom_host=None,
+                ),
+            ),
+            FabricInfo(
+                id="777",
+                name="airflow_oss_fabric",
+                type=FabricType.Airflow,
+                provider=FabricProviderType.OpenSource,
+                airflow_oss=OpenSourceAirflowInfo(
+                    airflow_url="https://airflow.test",
+                    airflow_username="airflow-user",
+                    airflow_password="secret-airflow-password",
+                    uploader_url="https://uploader.test",
+                    uploader_username="uploader-user",
+                    uploader_password="secret-uploader-password",
+                    dag_location="/dags",
+                    location="us",
+                ),
+            ),
+            FabricInfo(
+                id="888",
+                name="composer_fabric",
+                type=FabricType.Airflow,
+                provider=FabricProviderType.Composer,
+                composer=ComposerInfo(
+                    key_json="secret-composer-key-json",
+                    version="2.5.1",
+                    project_id="test-gcp-project",
+                    airflow_url="https://composer.test",
+                    dag_location="gs://dags",
+                ),
+            ),
+            FabricInfo(
+                id="999",
+                name="dataproc_fabric",
+                type=FabricType.Spark,
+                provider=FabricProviderType.Dataproc,
+                dataproc=DataprocInfo(
+                    bucket="gs://test-bucket/prefix",
+                    project_id="test-gcp-project",
+                    key_json="secret-dataproc-key-json",
+                    location="us",
+                ),
+            ),
+        ],
+        project_git_tokens=[ProjectAndGitTokens(project_id="72805", git_token="secret-git-token")],
+    )
+
+
+def leaked_secrets(text):
+    return [secret for secret in SECRET_VALUES if secret in text]
+
+
+def test_fabric_not_found_error_does_not_expose_secrets():
+    factory = RestClientFactory(build_fabric_config())
+
+    with pytest.raises(ValueError) as exc_info:
+        factory._get_fabric_info("7")
+
+    message = str(exc_info.value)
+    assert leaked_secrets(message) == [], f"error message exposed secrets: {message}"
+    assert "Fabric Id 7 is not found in the fabric configs" in message
+    assert "['12038', '555', '666', '777', '888', '999']" in message
+
+
+def test_missing_databricks_config_error_does_not_expose_secrets():
+    fabric_config = build_fabric_config()
+    factory = RestClientFactory(fabric_config)
+
+    with pytest.raises(ValueError) as exc_info:
+        factory.databricks_client("888")
+
+    message = str(exc_info.value)
+    assert leaked_secrets(message) == [], f"error message exposed secrets: {message}"
+    assert "does not have a databricks configuration defined" in message
+    assert "composer_fabric" in message


### PR DESCRIPTION
### Prerequisites

- [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same change?
- [x] Added any Screenshot / video / logs confirming solution to be working

### Current Behaviour (MANDATORY)

Fabric credentials were being printed verbatim into the deployment/release logs that are shown in the UI.

`RestClientFactory._get_fabric_info` interpolated the entire `FabricConfig` object into its "fabric not found" error:

```python
raise ValueError(f"Fabric Id {fabric_id} is not found in the fabric configs {self.fabric_config}")
```

`FabricConfig` is a pydantic model, so its `__str__` dumps every field it holds. `LogEvent.from_log` then appends `str(exception)` to the log line, and that line is surfaced as-is in the Release Logs panel:

```python
log = f"{log} exception message: {str(ex)}: Stacktrace: {'  '.join(captured_trace.splitlines())}"
```

Observed on a `SQL_DatabricksSharedBasic` deploy, where a stale fabric reference (`Fabric Id 7`) made the `Upload dbt secrets` step fail:

```
...ing dbt secret for component Model_0  exception message: Fabric Id 7 is not found in the
fabric configs fabrics=[FabricInfo(id='12038', name='dev_databricks_unified_fabric',
type=<FabricType.Sql: 'Sql'>, provider=<FabricProviderType.Databricks: ...
```

Everything the fabric config carries was exposed this way: `DatabricksInfo.token`, `OAuthCredentials.client_secret`, `EMRInfo.access_key_id` / `secret_access_key` / `session_token`, `MwaaInfo.access_key` / `secret_key`, `ComposerInfo.key_json`, `DataprocInfo.key_json`, `OpenSourceAirflowInfo.airflow_password` / `uploader_password`, and `ProjectAndGitTokens.git_token`. Any fabric configured on the control plane was in scope, not just the one being deployed.

A second instance of the same mistake was present in `databricks_client`, which interpolated the whole `FabricInfo` (including its Databricks token) into its error message.

### Fix Made (MANDATORY)

Both messages in `rest_client_factory.py` now report only non-sensitive identifiers.

The "fabric not found" error reports the id that was looked up plus the ids that are available, which is the information actually needed to debug it:

```
Fabric Id 7 is not found in the fabric configs. Available fabric ids: ['12038', '555', '666', '777', '888', '999']
```

The `databricks_client` error names the fabric instead of dumping its `FabricInfo` (and reuses the `fabric_info` it had already fetched rather than looking it up a second time):

```
Fabric Id 888 (name 'composer_fabric', provider FabricProviderType.Composer) does not have a databricks configuration defined.
```

No behaviour changes beyond the text of these two error messages. The stacktrace appended by `LogEvent.from_log` is safe: `traceback.format_exc` renders the literal source line, not interpolated values.

Note the underlying `Fabric Id 7 is not found` failure is a separate issue (a stale fabric reference in the project) and is not addressed here — this PR only stops the credential leak.

### Documentation (MANDATORY for features)

N/A — bug fix, no user-facing behaviour change beyond the wording of two error messages.

### Asana Ticket (MANDATORY)

Asana Ticket Links: << https://app.asana.com/1/711615303573503/project/1203813959485797/task/1217010423386023?focus=true >>

### Test Plan (MANDATORY if asana has tag feature/hotfix/qa)

QA Required (Yes/No): Yes

Regression Required (Yes/No): No

A) Please describe the dev tests that you ran to verify your changes (or the doc link)
- Added `test/test_error_message_secrets.py` (2 tests, passing) which builds a `FabricConfig` carrying a sentinel secret for every credential field across all fabric providers (Databricks + OAuth, EMR, MWAA, Composer, Dataproc, open-source Airflow, project git tokens) and asserts none of them appear in either error message. Both tests fail against the pre-fix code and pass after.
- Reproduced the exact message shape from the ticket against the pre-fix code, confirmed the credential dump, and confirmed it is gone after the fix.
- Full suite: `pytest test/*.py` → 88 passed, 16 failed. The same 16 fail identically on a clean tree at the base commit (they need a local maven/spark build env), so there is no regression from this change.
- `black --check` clean at line-length 120.

B) Please describe the tests that you expect the QA team to run to verify your changes (or the doc link)
- check for the case mentioned in Asana, that should suffice 

### Unit Tests (if applicable)

A) Tests (or the doc link)
- `test_fabric_not_found_error_does_not_expose_secrets` — the ticket's exact failure path; asserts no sentinel secret appears in the message and that available fabric ids are reported instead.
- `test_missing_databricks_config_error_does_not_expose_secrets` — the second leak site in `databricks_client`; asserts the message names the fabric and leaks nothing.

B) Percentage Code Coverage: 0%

### Master PR (if PR against release* then this is mandatory)

N/A — this PR targets `main`. Flagged as a hotfix candidate for 4.2.11.0, cherry-pick to the release branch to follow.
